### PR TITLE
fix: DialogInfo 中 contentColor 参数没有传进去

### DIFF
--- a/tdesign-component/lib/src/components/dialog/td_dialog_widget.dart
+++ b/tdesign-component/lib/src/components/dialog/td_dialog_widget.dart
@@ -186,6 +186,7 @@ class TDDialogInfoWidget extends StatelessWidget {
                       scrollDirection: Axis.vertical,
                       child: TDDialogContent(
                         content: content!,
+                        contentColor: contentColor ?? Color(0x99000000)
                       ),
                     ),
                   ),

--- a/tdesign-component/lib/src/components/dialog/td_dialog_widget.dart
+++ b/tdesign-component/lib/src/components/dialog/td_dialog_widget.dart
@@ -186,7 +186,7 @@ class TDDialogInfoWidget extends StatelessWidget {
                       scrollDirection: Axis.vertical,
                       child: TDDialogContent(
                         content: content!,
-                        contentColor: contentColor ?? Color(0x99000000)
+                        contentColor: contentColor ?? const Color(0x99000000),
                       ),
                     ),
                   ),


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 💡 需求背景和解决方案

原本的 `TDDialogInfoWidget` 中 `TDDialogContent` 没有传 contentColor 参数进去

### 📝 更新日志

- fix: 修复了 Dialog 指定 contentColor 无效


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
