### PR TITLE
日期选择器的年份支持显示对应年的农历生肖属性

### DIFF
--- a/tdesign-component/example/lib/page/td_date_picker_page.dart
+++ b/tdesign-component/example/lib/page/td_date_picker_page.dart
@@ -38,6 +38,7 @@ class _TDDatePickerPageState extends State<TDDatePickerPage> {
         children: [
           ExampleModule(title: '组件类型',
             children: [
+              ExampleItem(desc: '年份带生肖的选择器', builder: buildYearMonthDayNeedZodiac),
               ExampleItem(desc: '年月日选择器', builder: buildYearMonthDay),
               ExampleItem(desc: '年月选择器', builder: buildYearMonth),
               ExampleItem(desc: '月日选择器', builder: buildMonthDay),
@@ -53,6 +54,25 @@ class _TDDatePickerPageState extends State<TDDatePickerPage> {
             ],
           )
         ]);
+  }
+
+  @Demo(group: 'datetimePicker')
+  Widget buildYearMonthDayNeedZodiac(BuildContext context) {
+    return GestureDetector(
+      onTap: (){
+        TDPicker.showDatePicker(context, title: '选择时间',
+            needYearZodiac: true,
+            onConfirm: (selected) {
+              setState(() {
+                selected_1 = '${selected['year'].toString().padLeft(4, '0')}-${selected['month'].toString().padLeft(2, '0')}-${selected['day'].toString().padLeft(2, '0')}';
+              });
+            },
+            dateStart: [1999, 01, 01],
+            dateEnd: [2023, 12, 31],
+            initialDate: [2012, 1, 1]);
+      },
+      child: buildSelectRow(context, selected_1, '选择时间'),
+    );
   }
 
   @Demo(group: 'datetimePicker')

--- a/tdesign-component/example/pubspec.yaml
+++ b/tdesign-component/example/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   http: ^0.13.5
   tdesign_flutter:
     path: ../
+  lunar: ^1.6.1
 
 dev_dependencies:
   flutter_test:

--- a/tdesign-component/lib/src/components/picker/td_date_picker.dart
+++ b/tdesign-component/lib/src/components/picker/td_date_picker.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:lunar/lunar.dart';
 
 import '../../../tdesign_flutter.dart';
 import 'no_wave_behavior.dart';
@@ -32,6 +33,7 @@ class TDDatePicker extends StatefulWidget {
         this.showTitle = true,
         this.pickerHeight = 200,
         required this.pickerItemCount,
+        this.needYearZodiac = false,
         Key? key})
       : super(key: key);
 
@@ -94,6 +96,9 @@ class TDDatePicker extends StatefulWidget {
 
   /// 是否展示标题
   final bool showTitle;
+
+  // 是否需要展示年份的生肖
+  final bool needYearZodiac;
 
   /// 数据模型
   final DatePickerModel model;
@@ -275,9 +280,10 @@ class _TDDatePickerState extends State<TDDatePicker> {
                           index: index,
                           itemHeight: pickerHeight / widget.pickerItemCount,
                           content: whichLine == 3
-                              ? widget.model.mapping[whichLine] +
-                              widget.model.weekMap[widget.model.data[whichLine][index] - 1]
-                              : widget.model.data[whichLine][index].toString() + widget.model.mapping[whichLine],
+                              ? widget.model.mapping[whichLine] + widget.model.weekMap[widget.model.data[whichLine][index] - 1]
+                              : whichLine==0 && widget.needYearZodiac ?
+                                  widget.model.data[whichLine][index].toString() + Lunar.fromYmd(widget.model.data[whichLine][index], 1, 1).getYearShengXiao()+ widget.model.mapping[whichLine]
+                                  : widget.model.data[whichLine][index].toString() + widget.model.mapping[whichLine],
                           fixedExtentScrollController: widget.model.controllers[whichLine],
                           itemDistanceCalculator: widget.itemDistanceCalculator,
                         ));

--- a/tdesign-component/lib/src/components/picker/td_picker.dart
+++ b/tdesign-component/lib/src/components/picker/td_picker.dart
@@ -16,6 +16,7 @@ class TDPicker {
       bool useMinute = false,
       bool useSecond = false,
       bool useWeekDay = false,
+      bool needYearZodiac = false,
       Color? barrierColor,
       List<int> dateStart = const [1970, 1, 1],
       List<int>? dateEnd,
@@ -42,6 +43,7 @@ class TDPicker {
               onCancel: onCancel,
               rightText: rightText,
               leftText: leftText,
+              needYearZodiac: needYearZodiac,
               model: DatePickerModel(
                 useYear: useYear,
                 useMonth: useMonth,

--- a/tdesign-component/pubspec.yaml
+++ b/tdesign-component/pubspec.yaml
@@ -21,6 +21,7 @@ dev_dependencies:
   flutter_lints: ^1.0.4
   flutter_test:
     sdk: flutter
+  lunar: ^1.6.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
已经有其他人提 issue 了，我在群里也提了
https://github.com/Tencent/tdesign-flutter/issues/43

### 💡 需求背景和解决方案

1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
引入农历转换的lunar包依赖，支持选择性的显示农历生肖（后续可以支持农历日历选择）
5. 涉及UI/交互变动需要有截图或 GIF。
<img width="271" alt="image" src="https://github.com/Tencent/tdesign-flutter/assets/33625547/1eb9560d-5aa7-4ebb-be67-d957339e2b1c">


### 📝 更新日志
支持选择性的显示年份的农历生肖

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
