### PR TITLE
修复TDButton无法获取自定义主题颜色的问题

### DIFF
--- a/tdesign-component/example/lib/main_run.dart
+++ b/tdesign-component/example/lib/main_run.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:tdesign_flutter/src/util/log.dart';
 import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 import 'base/example_base.dart';
@@ -376,6 +377,7 @@ List<ExamplePageModel> sideBarExamplePage = [
 ];
 
 void main() {
+  Log.setCustomLogPrinter((level, tag, msg) => print('[$level] $tag ==> $msg'));
   runApp(const MyApp());
 
   SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(

--- a/tdesign-component/example/lib/page/td_theme_page.dart
+++ b/tdesign-component/example/lib/page/td_theme_page.dart
@@ -251,6 +251,10 @@ class TestWidget extends StatelessWidget {
             textColor:
                 TDTheme.of(context).successNormalColor, // 明确使用内层主题，必须传context
           ),
+          const TDButton(
+            text:  '使用内层赋值主题',
+            theme: TDButtonTheme.primary,
+          ),
           TDText(
             '使用默认主题',
             font:

--- a/tdesign-component/lib/src/components/button/td_button.dart
+++ b/tdesign-component/lib/src/components/button/td_button.dart
@@ -115,25 +115,21 @@ class _TDButtonState extends State<TDButton> {
   TDButtonStyle? _innerDisableStyle;
   double? _width;
   double? _height;
-  EdgeInsetsGeometry? _padding;
   EdgeInsetsGeometry? _margin;
   Alignment? _alignment;
-  Font? _textFont;
   TextStyle? _textStyle;
   double? _iconSize;
 
-  _updateParams(){
+  _updateParams() async {
     _buttonStatus = widget.disabled ? TDButtonStatus.disable : TDButtonStatus.defaultState;
     _innerDefaultStyle = widget.style ?? _innerDefaultStyle;
     _innerActiveStyle = widget.activeStyle ?? _innerActiveStyle;
     _innerDisableStyle = widget.disableStyle ?? _innerDisableStyle;
     _width = _getWidth();
     _height = _getHeight();
-    _padding = _getPadding();
     _margin = _getMargin();
     _alignment =  widget.shape == TDButtonShape.filled || widget.isBlock ? Alignment.center : null;
     if (widget.text != null) {
-      _textFont = _getTextFont();
       _textStyle = widget.disabled ? widget.disableTextStyle : widget.textStyle;
     }
     if(widget.icon != null){
@@ -165,7 +161,7 @@ class _TDButtonState extends State<TDButton> {
       width: _width,
       height: _height,
       alignment: _alignment,
-      padding: _padding,
+      padding: _getPadding(),
       margin: _margin,
       decoration: BoxDecoration(
         color: style.backgroundColor,
@@ -234,7 +230,7 @@ class _TDButtonState extends State<TDButton> {
     if (widget.text != null) {
       var text = TDText(
         widget.text!,
-        font: _textFont,
+        font: _getTextFont(),
         textColor:
         style.textColor ?? TDTheme.of(context).fontGyColor1,
         style: _textStyle,

--- a/tdesign-component/lib/src/theme/td_theme.dart
+++ b/tdesign-component/lib/src/theme/td_theme.dart
@@ -64,6 +64,7 @@ class TDTheme extends StatelessWidget {
         var data = Theme.of(context).extensions[TDThemeData] as TDThemeData?;
         return data ?? TDThemeData.defaultData();
       } catch (e) {
+      Log.w('TDTheme', 'TDTheme.of() error: $e');
         return TDThemeData.defaultData();
       }
   }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-flutter/issues/54

### 💡 需求背景和解决方案

TDButton优化性能的时候，将一部分赋值操作放到了initState周期，因为该周期context没有准备好，导致获取主题颜色失败。

### 📝 更新日志



- fix(TDButton): 修复无法获取自定义主题颜色的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x ] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
