### PR TITLE
refactor(td_badge_page)/feat(td_badge):Badge 组件类型演示代码拆分/Badge新增maxCount

### DIFF
--- a/tdesign-component/example/lib/page/td_badge_page.dart
+++ b/tdesign-component/example/lib/page/td_badge_page.dart
@@ -21,9 +21,123 @@ class _TDBadgePageState extends State<TDBadgePage> {
           ExampleModule(
             title: '组件类型',
             children: [
-              ExampleItem(desc: '红点徽标', builder: _buildRedPointBadge),
-              ExampleItem(desc: '数字徽标', builder: _buildNumberBadge),
-              ExampleItem(desc: '自定义徽标', builder: _buildCustomBadge),
+              ExampleItem(
+                  ignoreCode: true,
+                  desc: '红点徽标',
+                  builder: (context) {
+                    return Container(
+                      alignment: Alignment.topLeft,
+                      padding: const EdgeInsets.only(left: 16),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center, // 垂直方向上末端对齐
+                        children: [
+                            Container(
+                              alignment: Alignment.bottomLeft,
+                              margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                              child: CodeWrapper(
+                                builder: _buildRedPointMessageBadge,
+                                methodName: '_buildRedPointMessageBadge',
+                              ),
+                            ),
+                            Container(
+                              alignment: Alignment.bottomLeft,
+                              margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                              child: CodeWrapper(
+                                builder: _buildRedPointIconBadge,
+                                methodName: '_buildRedPointIconBadge',
+                              ),
+                            ),
+                            Container(
+                              alignment: Alignment.bottomLeft,
+                              margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                              child: CodeWrapper(
+                                builder: _buildRedPointButtonBadge,
+                                methodName: '_buildRedPointButtonBadge',
+                              ),
+                            ),
+
+                        ],
+                      ),
+                    );
+                  }),
+
+              ExampleItem(
+                  ignoreCode: true,
+                  desc: '数字徽标',
+                  builder: (context) {
+                    return Container(
+                      alignment: Alignment.topLeft,
+                      padding: const EdgeInsets.only(left: 16),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center, // 垂直方向上末端对齐
+                        children: [
+                          Container(
+                            alignment: Alignment.bottomLeft,
+                            margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                            child: CodeWrapper(
+                              builder: _buildMessageNumberBadge,
+                              methodName: '_buildMessageNumberBadge',
+                            ),
+                          ),
+                          Container(
+                            alignment: Alignment.bottomLeft,
+                            margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                            child: CodeWrapper(
+                              builder: _buildIconNumberBadge,
+                              methodName: '_buildIconNumberBadge',
+                            ),
+                          ),
+                          Container(
+                            alignment: Alignment.bottomLeft,
+                            margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                            child: CodeWrapper(
+                              builder: _buildButtonNumberBadge,
+                              methodName: '_buildButtonNumberBadge',
+                            ),
+                          ),
+
+                        ],
+                      ),
+                    );
+                  }),
+              ExampleItem(
+                  ignoreCode: true,
+                  desc: '自定义徽标',
+                  builder: (context) {
+                    return Container(
+                      alignment: Alignment.topLeft,
+                      padding: const EdgeInsets.only(left: 16),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center, // 垂直方向上末端对齐
+                        children: [
+                          Container(
+                            alignment: Alignment.bottomLeft,
+                            margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                            child: CodeWrapper(
+                              builder: _buildCustomBadgeShowingNumberEight,
+                              methodName: '_buildCustomBadgeShowingNumberEight',
+                            ),
+                          ),
+                          Container(
+                            alignment: Alignment.bottomLeft,
+                            margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                            child: CodeWrapper(
+                              builder: _buildCustomBadgeShowingNumberZero,
+                              methodName: '_buildCustomBadgeShowingNumberZero',
+                            ),
+                          ),
+                          Container(
+                            alignment: Alignment.bottomLeft,
+                            margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                            child: CodeWrapper(
+                              builder: _buildCustomBadgeWithoutShowingNumberZero,
+                              methodName: '_buildCustomBadgeWithoutShowingNumberZero',
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }),
             ],
           ),
           ExampleModule(
@@ -46,251 +160,241 @@ class _TDBadgePageState extends State<TDBadgePage> {
   }
 
   @Demo(group: 'badge')
-  Widget _buildRedPointBadge(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 16),
-      child: Row(
+  Widget _buildRedPointMessageBadge(BuildContext context) {
+    return SizedBox(
+      width: 40,
+      height: 24,
+      child: Stack(
+        alignment: Alignment.bottomLeft,
         children: [
-          SizedBox(
-            width: 40,
-            height: 24,
-            child: Stack(
-              alignment: Alignment.bottomLeft,
-              children: [
-                TDText(
-                  '消息',
-                  font: TDTheme.of(context).fontBodyLarge,
-                ),
-                const Positioned(
-                  child: TDBadge(TDBadgeType.redPoint),
-                  right: 0,
-                  top: 0,
-                )
-              ],
-            ),
+          TDText(
+            '消息',
+            font: TDTheme.of(context).fontBodyLarge,
           ),
-          const SizedBox(
-            width: 40,
-          ),
-          SizedBox(
-            width: 27,
-            height: 27,
-            child: Stack(
-              alignment: Alignment.bottomLeft,
-              children: const [
-                Icon(TDIcons.notification),
-                Positioned(
-                  child: TDBadge(TDBadgeType.redPoint),
-                  right: 0,
-                  top: 0,
-                )
-              ],
-            ),
-          ),
-          const SizedBox(
-            width: 40,
-          ),
-          SizedBox(
-            width: 83,
-            height: 51,
-            child: Stack(
-              alignment: Alignment.bottomLeft,
-              children: const [
-                TDButton(
-                  width: 80,
-                  height: 48,
-                  text: '按钮',
-                  size: TDButtonSize.large,
-                  type: TDButtonType.fill,
-                ),
-                Positioned(
-                  child: TDBadge(TDBadgeType.redPoint),
-                  right: 0,
-                  top: 0,
-                )
-              ],
-            ),
-          ),
+          const Positioned(
+            child: TDBadge(TDBadgeType.redPoint),
+            right: 0,
+            top: 0,
+          )
         ],
       ),
     );
   }
 
   @Demo(group: 'badge')
-  Widget _buildNumberBadge(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 16),
-      child: Row(
+  Widget _buildRedPointIconBadge(BuildContext context) {
+    return const SizedBox(
+      width: 27,
+      height: 27,
+      child: Stack(
+        alignment: Alignment.bottomLeft,
         children: [
-          SizedBox(
+          Icon(TDIcons.notification),
+          Positioned(
+            child: TDBadge(TDBadgeType.redPoint),
+            right: 0,
+            top: 0,
+          )
+        ],
+      ),
+    );
+  }
+
+  @Demo(group: 'badge')
+  Widget _buildRedPointButtonBadge(BuildContext context) {
+    return const SizedBox(
+      width: 83,
+      height: 48,
+      child: Stack(
+        alignment: Alignment.bottomLeft,
+        children: [
+          TDButton(
+            width: 80,
+            height: 48,
+            text: '按钮',
+            size: TDButtonSize.large,
+            type: TDButtonType.fill,
+          ),
+          Positioned(
+            child: TDBadge(TDBadgeType.redPoint),
+            right: 0,
+            top: 0,
+          )
+        ],
+      ),
+    );
+  }
+
+  @Demo(group: 'badge')
+  Widget _buildMessageNumberBadge(BuildContext context) {
+    return SizedBox(
+      width: 48,
+      height: 32,
+      child: Stack(
+        alignment: Alignment.bottomLeft,
+        children: [
+          TDText(
+            '消息',
+            font: TDTheme.of(context).fontBodyLarge,
+          ),
+          const Positioned(
+            child: TDBadge(
+              TDBadgeType.message,
+              count: '8',
+            ),
+            right: 0,
+            top: 0,
+          )
+        ],
+      ),
+    );
+  }
+
+  @Demo(group: 'badge')
+  Widget _buildIconNumberBadge(BuildContext context) {
+    return const SizedBox(
+      width: 34,
+      height: 34,
+      child: Stack(
+        alignment: Alignment.bottomLeft,
+        children: [
+          Icon(TDIcons.notification),
+          Positioned(
+            child: TDBadge(
+              TDBadgeType.message,
+              count: '8',
+            ),
+            right: 0,
+            top: 0,
+          )
+        ],
+      ),
+    );
+  }
+
+  @Demo(group: 'badge')
+  Widget _buildButtonNumberBadge(BuildContext context) {
+    return const SizedBox(
+      width: 86,
+      height: 54,
+      child: Stack(
+        alignment: Alignment.bottomLeft,
+        children: [
+          TDButton(
+            width: 80,
+            height: 48,
+            text: '按钮',
+            size: TDButtonSize.large,
+          ),
+          Positioned(
+            child: TDBadge(
+              TDBadgeType.message,
+              count: '8',
+            ),
+            right: 0,
+            top: 0,
+          )
+        ],
+      ),
+    );
+  }
+
+  @Demo(group: 'badge')
+  Widget _buildCustomBadgeShowingNumberEight(BuildContext context) {
+    return SizedBox(
+      width: 64,
+      height: 56,
+      child: Stack(
+        alignment: Alignment.bottomLeft,
+        children: [
+          Container(
+            child: const Icon(TDIcons.notification),
+            decoration: BoxDecoration(
+                color: TDTheme.of(context).grayColor2,
+                borderRadius: BorderRadius.circular(
+                    TDTheme.of(context).radiusDefault)),
+            height: 48,
             width: 48,
-            height: 32,
-            child: Stack(
-              alignment: Alignment.bottomLeft,
-              children: [
-                TDText(
-                  '消息',
-                  font: TDTheme.of(context).fontBodyLarge,
-                ),
-                const Positioned(
-                  child: TDBadge(
-                    TDBadgeType.message,
-                    count: '8',
-                  ),
-                  right: 0,
-                  top: 0,
-                )
-              ],
+          ),
+          const Positioned(
+            child: TDBadge(
+              TDBadgeType.message,
+              count: '8',
             ),
-          ),
-          const SizedBox(
-            width: 40,
-          ),
-          SizedBox(
-            width: 34,
-            height: 34,
-            child: Stack(
-              alignment: Alignment.bottomLeft,
-              children: const [
-                Icon(TDIcons.notification),
-                Positioned(
-                  child: TDBadge(
-                    TDBadgeType.message,
-                    count: '8',
-                  ),
-                  right: 0,
-                  top: 0,
-                )
-              ],
-            ),
-          ),
-          const SizedBox(
-            width: 40,
-          ),
-          SizedBox(
-            width: 86,
-            height: 54,
-            child: Stack(
-              alignment: Alignment.bottomLeft,
-              children: const [
-                TDButton(
-                  width: 80,
-                  height: 48,
-                  text: '按钮',
-                  size: TDButtonSize.large,
-                ),
-                Positioned(
-                  child: TDBadge(
-                    TDBadgeType.message,
-                    count: '8',
-                  ),
-                  right: 0,
-                  top: 0,
-                )
-              ],
-            ),
-          ),
+            right: 0,
+            top: 0,
+          )
         ],
       ),
     );
   }
 
   @Demo(group: 'badge')
-  Widget _buildCustomBadge(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 16),
-      child: Row(
+  Widget _buildCustomBadgeShowingNumberZero(BuildContext context) {
+    return SizedBox(
+      width: 64,
+      height: 56,
+      child: Stack(
+        alignment: Alignment.bottomLeft,
         children: [
-          SizedBox(
-            width: 64,
-            height: 56,
-            child: Stack(
-              alignment: Alignment.bottomLeft,
-              children: [
-                Container(
-                  child: const Icon(TDIcons.notification),
-                  decoration: BoxDecoration(
-                      color: TDTheme.of(context).grayColor2,
-                      borderRadius: BorderRadius.circular(
-                          TDTheme.of(context).radiusDefault)),
-                  height: 48,
-                  width: 48,
-                ),
-                const Positioned(
-                  child: TDBadge(
-                    TDBadgeType.message,
-                    count: '8',
-                  ),
-                  right: 0,
-                  top: 0,
-                )
-              ],
-            ),
+          Container(
+            child: const Icon(TDIcons.notification),
+            decoration: BoxDecoration(
+                color: TDTheme.of(context).grayColor2,
+                borderRadius: BorderRadius.circular(
+                    TDTheme.of(context).radiusDefault)),
+            height: 48,
+            width: 48,
           ),
-          const SizedBox(width: 40),
-          SizedBox(
-            width: 64,
-            height: 56,
-            child: Stack(
-              alignment: Alignment.bottomLeft,
-              children: [
-                Container(
-                  child: const Icon(TDIcons.notification),
-                  decoration: BoxDecoration(
-                      color: TDTheme.of(context).grayColor2,
-                      borderRadius: BorderRadius.circular(
-                          TDTheme.of(context).radiusDefault)),
-                  height: 48,
-                  width: 48,
-                ),
-                const Positioned(
-                  child: TDBadge(
-                    TDBadgeType.message,
-                    count: '0',
-                  ),
-                  right: 0,
-                  top: 0,
-                )
-              ],
+          const Positioned(
+            child: TDBadge(
+              TDBadgeType.message,
+              count: '0',
             ),
-          ),
-          const SizedBox(width: 40),
-          SizedBox(
-            width: 64,
-            height: 56,
-            child: Stack(
-              alignment: Alignment.bottomLeft,
-              children: [
-                Container(
-                  child: const Icon(TDIcons.notification),
-                  decoration: BoxDecoration(
-                      color: TDTheme.of(context).grayColor2,
-                      borderRadius: BorderRadius.circular(
-                          TDTheme.of(context).radiusDefault)),
-                  height: 48,
-                  width: 48,
-                ),
-                const Positioned(
-                  child: TDBadge(
-                    TDBadgeType.message,
-                    count: '0',
-                    showZero: false,
-                  ),
-                  right: 0,
-                  top: 0,
-                )
-              ],
-            ),
-          ),
+            right: 0,
+            top: 0,
+          )
         ],
       ),
     );
   }
+
+  @Demo(group: 'badge')
+  Widget _buildCustomBadgeWithoutShowingNumberZero(BuildContext context) {
+    return SizedBox(
+      width: 64,
+      height: 56,
+      child: Stack(
+        alignment: Alignment.bottomLeft,
+        children: [
+          Container(
+            child: const Icon(TDIcons.notification),
+            decoration: BoxDecoration(
+                color: TDTheme.of(context).grayColor2,
+                borderRadius: BorderRadius.circular(
+                    TDTheme.of(context).radiusDefault)),
+            height: 48,
+            width: 48,
+          ),
+          const Positioned(
+            child: TDBadge(
+              TDBadgeType.message,
+              count: '0',
+              showZero: false,
+            ),
+            right: 0,
+            top: 0,
+          )
+        ],
+      ),
+    );
+  }
+
 
   @Demo(group: 'badge')
   Widget _buildCircleBadge(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 16),
+    return const Padding(
+      padding: EdgeInsets.only(left: 16),
       child: Row(
         children: [
           SizedBox(
@@ -298,7 +402,7 @@ class _TDBadgePageState extends State<TDBadgePage> {
             height: 34,
             child: Stack(
               alignment: Alignment.bottomLeft,
-              children: const [
+              children: [
                 Icon(TDIcons.notification),
                 Positioned(
                   child: TDBadge(
@@ -318,8 +422,8 @@ class _TDBadgePageState extends State<TDBadgePage> {
 
   @Demo(group: 'badge')
   Widget _buildSquareBadge(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 16),
+    return const Padding(
+      padding: EdgeInsets.only(left: 16),
       child: Row(
         children: [
           SizedBox(
@@ -327,7 +431,7 @@ class _TDBadgePageState extends State<TDBadgePage> {
             height: 34,
             child: Stack(
               alignment: Alignment.bottomLeft,
-              children: const [
+              children: [
                 Icon(TDIcons.notification),
                 Positioned(
                   child: TDBadge(
@@ -410,8 +514,8 @@ class _TDBadgePageState extends State<TDBadgePage> {
 
   @Demo(group: 'badge')
   Widget _buildLargeBadge(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 16),
+    return const Padding(
+      padding: EdgeInsets.only(left: 16),
       child: Row(
         children: [
           SizedBox(
@@ -419,7 +523,7 @@ class _TDBadgePageState extends State<TDBadgePage> {
             height: 65.5,
             child: Stack(
               alignment: Alignment.bottomLeft,
-              children: const [
+              children: [
                 TDAvatar(
                   size: TDAvatarSize.large,
                   type: TDAvatarType.icon,
@@ -443,8 +547,8 @@ class _TDBadgePageState extends State<TDBadgePage> {
 
   @Demo(group: 'badge')
   Widget _buildMediumBadge(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 16),
+    return const Padding(
+      padding: EdgeInsets.only(left: 16),
       child: Row(
         children: [
           SizedBox(
@@ -452,7 +556,7 @@ class _TDBadgePageState extends State<TDBadgePage> {
             height: 49.5,
             child: Stack(
               alignment: Alignment.bottomLeft,
-              children: const [
+              children: [
                 TDAvatar(
                   size: TDAvatarSize.medium,
                   type: TDAvatarType.icon,

--- a/tdesign-component/example/lib/page/td_badge_page.dart
+++ b/tdesign-component/example/lib/page/td_badge_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:tdesign_flutter/tdesign_flutter.dart';
 import '../../base/example_widget.dart';
@@ -29,38 +30,36 @@ class _TDBadgePageState extends State<TDBadgePage> {
                       alignment: Alignment.topLeft,
                       padding: const EdgeInsets.only(left: 16),
                       child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.center, // 垂直方向上末端对齐
+                        crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
-                            Container(
-                              alignment: Alignment.bottomLeft,
-                              margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
-                              child: CodeWrapper(
-                                builder: _buildRedPointMessageBadge,
-                                methodName: '_buildRedPointMessageBadge',
-                              ),
+                          Container(
+                            alignment: Alignment.bottomLeft,
+                            margin: const EdgeInsets.only(
+                                top: 8, left: 16, right: 16, bottom: 8),
+                            child: CodeWrapper(
+                              builder: _buildRedPointMessageBadge,
                             ),
-                            Container(
-                              alignment: Alignment.bottomLeft,
-                              margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
-                              child: CodeWrapper(
-                                builder: _buildRedPointIconBadge,
-                                methodName: '_buildRedPointIconBadge',
-                              ),
+                          ),
+                          Container(
+                            alignment: Alignment.bottomLeft,
+                            margin: const EdgeInsets.only(
+                                top: 8, left: 16, right: 16, bottom: 8),
+                            child: CodeWrapper(
+                              builder: _buildRedPointIconBadge,
                             ),
-                            Container(
-                              alignment: Alignment.bottomLeft,
-                              margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
-                              child: CodeWrapper(
-                                builder: _buildRedPointButtonBadge,
-                                methodName: '_buildRedPointButtonBadge',
-                              ),
+                          ),
+                          Container(
+                            alignment: Alignment.bottomLeft,
+                            margin: const EdgeInsets.only(
+                                top: 8, left: 16, right: 16, bottom: 8),
+                            child: CodeWrapper(
+                              builder: _buildRedPointButtonBadge,
                             ),
-
+                          ),
                         ],
                       ),
                     );
                   }),
-
               ExampleItem(
                   ignoreCode: true,
                   desc: '数字徽标',
@@ -69,33 +68,33 @@ class _TDBadgePageState extends State<TDBadgePage> {
                       alignment: Alignment.topLeft,
                       padding: const EdgeInsets.only(left: 16),
                       child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.center, // 垂直方向上末端对齐
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        // 垂直方向上末端对齐
                         children: [
                           Container(
                             alignment: Alignment.bottomLeft,
-                            margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                            margin: const EdgeInsets.only(
+                                top: 8, left: 16, right: 16, bottom: 8),
                             child: CodeWrapper(
                               builder: _buildMessageNumberBadge,
-                              methodName: '_buildMessageNumberBadge',
                             ),
                           ),
                           Container(
                             alignment: Alignment.bottomLeft,
-                            margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                            margin: const EdgeInsets.only(
+                                top: 8, left: 16, right: 16, bottom: 8),
                             child: CodeWrapper(
                               builder: _buildIconNumberBadge,
-                              methodName: '_buildIconNumberBadge',
                             ),
                           ),
                           Container(
                             alignment: Alignment.bottomLeft,
-                            margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                            margin: const EdgeInsets.only(
+                                top: 8, left: 16, right: 16, bottom: 8),
                             child: CodeWrapper(
                               builder: _buildButtonNumberBadge,
-                              methodName: '_buildButtonNumberBadge',
                             ),
                           ),
-
                         ],
                       ),
                     );
@@ -108,30 +107,32 @@ class _TDBadgePageState extends State<TDBadgePage> {
                       alignment: Alignment.topLeft,
                       padding: const EdgeInsets.only(left: 16),
                       child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.center, // 垂直方向上末端对齐
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        // 垂直方向上末端对齐
                         children: [
                           Container(
                             alignment: Alignment.bottomLeft,
-                            margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                            margin: const EdgeInsets.only(
+                                top: 8, left: 16, right: 16, bottom: 8),
                             child: CodeWrapper(
                               builder: _buildCustomBadgeShowingNumberEight,
-                              methodName: '_buildCustomBadgeShowingNumberEight',
                             ),
                           ),
                           Container(
                             alignment: Alignment.bottomLeft,
-                            margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                            margin: const EdgeInsets.only(
+                                top: 8, left: 16, right: 16, bottom: 8),
                             child: CodeWrapper(
                               builder: _buildCustomBadgeShowingNumberZero,
-                              methodName: '_buildCustomBadgeShowingNumberZero',
                             ),
                           ),
                           Container(
                             alignment: Alignment.bottomLeft,
-                            margin: const EdgeInsets.only(top: 8, left: 16, right: 16, bottom: 8),
+                            margin: const EdgeInsets.only(
+                                top: 8, left: 16, right: 16, bottom: 8),
                             child: CodeWrapper(
-                              builder: _buildCustomBadgeWithoutShowingNumberZero,
-                              methodName: '_buildCustomBadgeWithoutShowingNumberZero',
+                              builder:
+                                  _buildCustomBadgeWithoutShowingNumberZero,
                             ),
                           ),
                         ],
@@ -154,6 +155,55 @@ class _TDBadgePageState extends State<TDBadgePage> {
             children: [
               ExampleItem(desc: 'Large', builder: _buildLargeBadge),
               ExampleItem(desc: 'Medium', builder: _buildMediumBadge)
+            ],
+          ),
+          ExampleModule(
+            title: '最大数字上限',
+            children: [
+              ExampleItem(
+                  ignoreCode: true,
+                  desc: '未超过上限',
+                  builder: (context) {
+                    return Container(
+                      alignment: Alignment.topLeft,
+                      padding: const EdgeInsets.only(left: 16),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Container(
+                            alignment: Alignment.bottomLeft,
+                            margin: const EdgeInsets.only(
+                                left: 16, right: 16, bottom: 8),
+                            child: CodeWrapper(
+                              builder: _buildLessThanMaxCountBadge,
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }),
+              ExampleItem(
+                  ignoreCode: true,
+                  desc: '超过上限',
+                  builder: (context) {
+                    return Container(
+                      alignment: Alignment.topLeft,
+                      padding: const EdgeInsets.only(left: 16),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Container(
+                            alignment: Alignment.bottomLeft,
+                            margin: const EdgeInsets.only(
+                                left: 16, right: 16, bottom: 8),
+                            child: CodeWrapper(
+                              builder: _buildMoreThanMaxCountBadge,
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }),
             ],
           )
         ]);
@@ -228,8 +278,8 @@ class _TDBadgePageState extends State<TDBadgePage> {
   @Demo(group: 'badge')
   Widget _buildMessageNumberBadge(BuildContext context) {
     return SizedBox(
-      width: 48,
-      height: 32,
+      width: 54,
+      height: 36,
       child: Stack(
         alignment: Alignment.bottomLeft,
         children: [
@@ -242,8 +292,8 @@ class _TDBadgePageState extends State<TDBadgePage> {
               TDBadgeType.message,
               count: '8',
             ),
-            right: 0,
-            top: 0,
+            left: 28,
+            bottom: 18,
           )
         ],
       ),
@@ -253,8 +303,8 @@ class _TDBadgePageState extends State<TDBadgePage> {
   @Demo(group: 'badge')
   Widget _buildIconNumberBadge(BuildContext context) {
     return const SizedBox(
-      width: 34,
-      height: 34,
+      width: 42,
+      height: 36,
       child: Stack(
         alignment: Alignment.bottomLeft,
         children: [
@@ -264,8 +314,8 @@ class _TDBadgePageState extends State<TDBadgePage> {
               TDBadgeType.message,
               count: '8',
             ),
-            right: 0,
-            top: 0,
+            left: 18,
+            bottom: 18,
           )
         ],
       ),
@@ -311,8 +361,8 @@ class _TDBadgePageState extends State<TDBadgePage> {
             child: const Icon(TDIcons.notification),
             decoration: BoxDecoration(
                 color: TDTheme.of(context).grayColor2,
-                borderRadius: BorderRadius.circular(
-                    TDTheme.of(context).radiusDefault)),
+                borderRadius:
+                    BorderRadius.circular(TDTheme.of(context).radiusDefault)),
             height: 48,
             width: 48,
           ),
@@ -341,8 +391,8 @@ class _TDBadgePageState extends State<TDBadgePage> {
             child: const Icon(TDIcons.notification),
             decoration: BoxDecoration(
                 color: TDTheme.of(context).grayColor2,
-                borderRadius: BorderRadius.circular(
-                    TDTheme.of(context).radiusDefault)),
+                borderRadius:
+                    BorderRadius.circular(TDTheme.of(context).radiusDefault)),
             height: 48,
             width: 48,
           ),
@@ -371,8 +421,8 @@ class _TDBadgePageState extends State<TDBadgePage> {
             child: const Icon(TDIcons.notification),
             decoration: BoxDecoration(
                 color: TDTheme.of(context).grayColor2,
-                borderRadius: BorderRadius.circular(
-                    TDTheme.of(context).radiusDefault)),
+                borderRadius:
+                    BorderRadius.circular(TDTheme.of(context).radiusDefault)),
             height: 48,
             width: 48,
           ),
@@ -390,7 +440,6 @@ class _TDBadgePageState extends State<TDBadgePage> {
     );
   }
 
-
   @Demo(group: 'badge')
   Widget _buildCircleBadge(BuildContext context) {
     return const Padding(
@@ -398,7 +447,7 @@ class _TDBadgePageState extends State<TDBadgePage> {
       child: Row(
         children: [
           SizedBox(
-            width: 34,
+            width: 48,
             height: 34,
             child: Stack(
               alignment: Alignment.bottomLeft,
@@ -407,10 +456,10 @@ class _TDBadgePageState extends State<TDBadgePage> {
                 Positioned(
                   child: TDBadge(
                     TDBadgeType.message,
-                    count: '8',
+                    count: '16',
                   ),
-                  right: 0,
-                  top: 0,
+                  left: 18,
+                  bottom: 18,
                 )
               ],
             ),
@@ -427,7 +476,7 @@ class _TDBadgePageState extends State<TDBadgePage> {
       child: Row(
         children: [
           SizedBox(
-            width: 34,
+            width: 48,
             height: 34,
             child: Stack(
               alignment: Alignment.bottomLeft,
@@ -437,10 +486,10 @@ class _TDBadgePageState extends State<TDBadgePage> {
                   child: TDBadge(
                     TDBadgeType.square,
                     border: TDBadgeBorder.small,
-                    count: '8',
+                    count: '16',
                   ),
-                  right: 0,
-                  top: 0,
+                  left: 20,
+                  bottom: 18,
                 )
               ],
             ),
@@ -520,7 +569,7 @@ class _TDBadgePageState extends State<TDBadgePage> {
         children: [
           SizedBox(
             width: 68,
-            height: 65.5,
+            height: 70,
             child: Stack(
               alignment: Alignment.bottomLeft,
               children: [
@@ -534,8 +583,8 @@ class _TDBadgePageState extends State<TDBadgePage> {
                     size: TDBadgeSize.large,
                     count: '8',
                   ),
-                  right: 0,
-                  top: 0,
+                  left: 48,
+                  bottom: 48,
                 )
               ],
             ),
@@ -547,13 +596,13 @@ class _TDBadgePageState extends State<TDBadgePage> {
 
   @Demo(group: 'badge')
   Widget _buildMediumBadge(BuildContext context) {
-    return const Padding(
-      padding: EdgeInsets.only(left: 16),
-      child: Row(
+    return Container(
+      padding: const EdgeInsets.only(left: 16),
+      child: const Row(
         children: [
           SizedBox(
-            width: 51,
-            height: 49.5,
+            width: 120,
+            height: 54,
             child: Stack(
               alignment: Alignment.bottomLeft,
               children: [
@@ -566,11 +615,67 @@ class _TDBadgePageState extends State<TDBadgePage> {
                     TDBadgeType.message,
                     count: '8',
                   ),
-                  right: 0,
-                  top: 0,
+                  left: 36,
+                  bottom: 36,
                 )
               ],
             ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @Demo(group: 'badge')
+  Widget _buildLessThanMaxCountBadge(BuildContext context) {
+    return const SizedBox(
+      width: 60,
+      height: 50,
+      child: Stack(
+        children: [
+          Positioned(
+            left: 0,
+            bottom: 0,
+            child: Icon(TDIcons.notification),
+          ),
+          Positioned(
+            child: TDBadge(
+              TDBadgeType.square,
+              count: '8888',
+              maxCount: '9000',
+              size: TDBadgeSize.large,
+              border: TDBadgeBorder.large,
+            ),
+            left: 18,
+            bottom: 18,
+          ),
+        ],
+      ),
+    );
+  }
+
+  @Demo(group: 'badge')
+  Widget _buildMoreThanMaxCountBadge(BuildContext context) {
+    return const SizedBox(
+      width: 60,
+      height: 50,
+      child: Stack(
+        children: [
+          Positioned(
+            left: 0,
+            bottom: 0,
+            child: Icon(TDIcons.notification),
+          ),
+          Positioned(
+            child: TDBadge(
+              TDBadgeType.square,
+              count: '888',
+              maxCount: '99',
+              size: TDBadgeSize.large,
+              border: TDBadgeBorder.large,
+            ),
+            left: 18,
+            bottom: 18,
           ),
         ],
       ),

--- a/tdesign-component/example/lib/page/td_badge_page.dart
+++ b/tdesign-component/example/lib/page/td_badge_page.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:tdesign_flutter/tdesign_flutter.dart';
 import '../../base/example_widget.dart';

--- a/tdesign-component/example/pubspec.lock
+++ b/tdesign-component/example/pubspec.lock
@@ -6,7 +6,7 @@ packages:
     description:
       name: args
       sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.0"
   async:
@@ -14,7 +14,7 @@ packages:
     description:
       name: async
       sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
   boolean_selector:
@@ -22,7 +22,7 @@ packages:
     description:
       name: boolean_selector
       sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   characters:
@@ -30,7 +30,7 @@ packages:
     description:
       name: characters
       sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   clock:
@@ -38,41 +38,41 @@ packages:
     description:
       name: clock
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
-      url: "https://pub.flutter-io.cn"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
-      url: "https://pub.flutter-io.cn"
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.8"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
-      url: "https://pub.flutter-io.cn"
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -83,7 +83,7 @@ packages:
     description:
       name: flutter_easyrefresh
       sha256: "5d161ee5dcac34da9065116568147d742dd25fb9bff3b10024d9054b195087ad"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
   flutter_lints:
@@ -91,7 +91,7 @@ packages:
     description:
       name: flutter_lints
       sha256: b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   flutter_localizations:
@@ -103,16 +103,16 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_markdown
-      sha256: "21b085a1c185e46701373866144ced56cfb7a0c33f63c916bb8fe2d0c1491278"
-      url: "https://pub.flutter-io.cn"
+      sha256: "04c4722cc36ec5af38acc38ece70d22d3c2123c61305d555750a091517bbe504"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.19"
+    version: "0.6.23"
   flutter_swiper_null_safety:
     dependency: "direct main"
     description:
       name: flutter_swiper_null_safety
       sha256: "5a855e0080d035c08e82f8b7fd2f106344943a30c9ab483b2584860a2f22eaaf"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   flutter_test:
@@ -125,7 +125,7 @@ packages:
     description:
       name: http
       sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.13.6"
   http_parser:
@@ -133,103 +133,119 @@ packages:
     description:
       name: http_parser
       sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   intl:
     dependency: "direct main"
     description:
       name: intl
-      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
-      url: "https://pub.flutter-io.cn"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
     source: hosted
-    version: "0.18.0"
-  js:
+    version: "0.19.0"
+  leak_tracker:
     dependency: transitive
     description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.flutter-io.cn"
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
       name: lints
       sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   markdown:
     dependency: transitive
     description:
       name: markdown
-      sha256: acf35edccc0463a9d7384e437c015a3535772e09714cf60e07eeef3a15870dcd
-      url: "https://pub.flutter-io.cn"
+      sha256: ef2a1298144e3f985cc736b22e0ccdaf188b5b3970648f2d9dc13efd1d9df051
+      url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "7.2.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
-      url: "https://pub.flutter-io.cn"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
-      url: "https://pub.flutter-io.cn"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
-      url: "https://pub.flutter-io.cn"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
-      url: "https://pub.flutter-io.cn"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: b27217933eeeba8ff24845c34003b003b2b22151de3c908d0e679e8fe1aa078b
-      url: "https://pub.flutter-io.cn"
+      sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "477184d672607c0a3bf68fbbf601805f92ef79c82b64b4d6eb318cbca4c48668"
-      url: "https://pub.flutter-io.cn"
+      sha256: bca87b0165ffd7cdb9cad8edd22d18d2201e886d9a9f19b4fb3452ea7df3a72a
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.6"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f"
-      url: "https://pub.flutter-io.cn"
+      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.0"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
       sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
@@ -237,7 +253,7 @@ packages:
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   path_provider_windows:
@@ -245,23 +261,23 @@ packages:
     description:
       name: path_provider_windows
       sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
-      url: "https://pub.flutter-io.cn"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
   sky_engine:
@@ -273,32 +289,32 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
-      url: "https://pub.flutter-io.cn"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
-      url: "https://pub.flutter-io.cn"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
-      url: "https://pub.flutter-io.cn"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   tdesign_flutter:
@@ -313,23 +329,23 @@ packages:
     description:
       name: term_glyph
       sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
-      url: "https://pub.flutter-io.cn"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
   vector_math:
@@ -337,25 +353,33 @@ packages:
     description:
       name: vector_math
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.2.1"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: "350a11abd2d1d97e0cc7a28a81b781c08002aa2864d9e3f192ca0ffa18b06ed3"
-      url: "https://pub.flutter-io.cn"
+      sha256: a79dbe579cb51ecd6d30b17e0cae4e0ea15e2c0e66f69ad4198f22a6789e94f4
+      url: "https://pub.dev"
     source: hosted
-    version: "5.0.9"
+    version: "5.5.1"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"

--- a/tdesign-component/lib/src/components/badge/td_badge.dart
+++ b/tdesign-component/lib/src/components/badge/td_badge.dart
@@ -43,6 +43,7 @@ class TDBadge extends StatefulWidget {
   const TDBadge(this.type,
       {Key? key,
       this.count,
+      this.maxCount = '99',
       this.border = TDBadgeBorder.large,
       this.size = TDBadgeSize.small,
       this.color,
@@ -56,6 +57,9 @@ class TDBadge extends StatefulWidget {
 
   /// 红点数量
   final String? count;
+
+  /// 最大红点数量
+  final String? maxCount;
 
   /// 红点样式
   final TDBadgeType type;
@@ -99,7 +103,14 @@ class _TDBadgeState extends State<TDBadge> {
       return;
     }
     setState(() {
-      badgeNum = newCount;
+      // 如果 newCount 超过了 maxCount，则显示 `${maxCount}+`
+      final countValue = int.tryParse(newCount) ?? 0;
+      final maxCountValue = int.tryParse(widget.maxCount ?? '') ?? 0;
+      if (maxCountValue > 0 && countValue > maxCountValue) {
+        badgeNum = '${maxCountValue}+';
+      } else {
+        badgeNum = newCount;
+      }
     });
   }
 
@@ -245,28 +256,30 @@ class _TDBadgeState extends State<TDBadge> {
       case TDBadgeType.square:
         return Visibility(
             visible: isVisible(),
-            child: Container(
-              height: getBadgeSize(),
-              width: getBadgeSize(),
-              padding: const EdgeInsets.only(left: 5, right: 5),
-              decoration: BoxDecoration(
-                color: widget.color ?? TDTheme.of(context).errorColor6,
-                borderRadius: widget.border == TDBadgeBorder.large
-                    ? BorderRadius.circular(8)
-                    : BorderRadius.circular(2),
-              ),
-              child: Center(
-                child: TDText(
-                  widget.message ?? '$badgeNum',
-                  forceVerticalCenter: true,
-                  font: getBadgeFont(context),
-                  fontWeight: FontWeight.w500,
-                  textColor:
-                      widget.textColor ?? TDTheme.of(context).whiteColor1,
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            ));
+            child: IntrinsicWidth(
+                child: Container(
+                  height: getBadgeSize(),
+                  padding: const EdgeInsets.only(left: 5, right: 5),
+                  decoration: BoxDecoration(
+                    color: widget.color ?? TDTheme.of(context).errorColor6,
+                    borderRadius: widget.border == TDBadgeBorder.large
+                        ? BorderRadius.circular(8)
+                        : BorderRadius.circular(2),
+                  ),
+                  child: Center(
+                    child: TDText(
+                      widget.message ?? '$badgeNum',
+                      forceVerticalCenter: true,
+                      font: getBadgeFont(context),
+                      fontWeight: FontWeight.w500,
+                      textColor:
+                        widget.textColor ?? TDTheme.of(context).whiteColor1,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                )
+            )
+        );
     }
   }
 }

--- a/tdesign-component/pubspec.lock
+++ b/tdesign-component/pubspec.lock
@@ -83,6 +83,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -95,34 +119,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -172,10 +196,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   vector_math:
     dependency: transitive
     description:
@@ -184,14 +208,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "14.2.1"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
-  flutter: ">=3.7.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-flutter/issues/206


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
具体问题：Badge的“组件类型”下面，多个演示组件使用同一份演示代码，演示代码太长，可读性不高。
实现：将原先ExampleItem中为三个不同组件一次性build的方法按照button代码中的样式拆分为三个不同的build方法，例如，将原先_buildRedPointBadge拆分为_buildRedPointMessageBadge、_buildRedPointIconBadge、_buildRedPointButtonBadge，把对排版的调整放到ExampleItem与其children的container中。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- refactor(td_badge_page): 解决了多个演示组件使用同一份演示代码，演示代码太长，可读性不高的问题。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
