### PR TITLE
feat(TDSwitch): 添加自定义“开/关”字体大小

### DIFF
--- a/tdesign-component/example/assets/api/switch_api.md
+++ b/tdesign-component/example/assets/api/switch_api.md
@@ -13,6 +13,8 @@
 | trackOffColor | Color? | - | 关闭时轨道颜色 |
 | thumbContentOnColor | Color? | - | 开启时ThumbView的颜色 |
 | thumbContentOffColor | Color? | - | 关闭时ThumbView的颜色 |
+| thumbContentOnFont | double? | - | 开启时ThumbView的字体大小 |
+| thumbContentOffFont | double? | - | 关闭时ThumbView的字体大小 |
 | onChanged | OnSwitchChanged? | - | 改变事件 |
 | openText | String? | - | 打开文案 |
 | closeText | String? | - | 关闭文案 |

--- a/tdesign-component/example/assets/api/switch_api.md
+++ b/tdesign-component/example/assets/api/switch_api.md
@@ -13,8 +13,8 @@
 | trackOffColor | Color? | - | 关闭时轨道颜色 |
 | thumbContentOnColor | Color? | - | 开启时ThumbView的颜色 |
 | thumbContentOffColor | Color? | - | 关闭时ThumbView的颜色 |
-| thumbContentOnFont | double? | - | 开启时ThumbView的字体大小 |
-| thumbContentOffFont | double? | - | 关闭时ThumbView的字体大小 |
+| thumbContentOnFont | TextStyle? | - | 开启时ThumbView的字体样式 |
+| thumbContentOffFont | TextStyle? | - | 关闭时ThumbView的字体样式 |
 | onChanged | OnSwitchChanged? | - | 改变事件 |
 | openText | String? | - | 打开文案 |
 | closeText | String? | - | 关闭文案 |

--- a/tdesign-component/example/assets/code/switch._customTextFont.txt
+++ b/tdesign-component/example/assets/code/switch._customTextFont.txt
@@ -6,8 +6,10 @@
         type: TDSwitchType.text,
         openText: '开',
         closeText: '关',
-        thumbContentOnFont: 16,
-        thumbContentOffFont: 10,
+        thumbContentOffColor: Colors.red,
+        thumbContentOnColor: Colors.green,
+        thumbContentOnFont: TextStyle(fontSize: 18),
+        thumbContentOffFont: TextStyle(fontSize: 12),
       ),
       title: '基础开关',
     );

--- a/tdesign-component/example/assets/code/switch._customTextFont.txt
+++ b/tdesign-component/example/assets/code/switch._customTextFont.txt
@@ -1,0 +1,14 @@
+
+  Widget _customTextFont(BuildContext context) {
+    return _buildItem(
+      context,
+      const TDSwitch(
+        type: TDSwitchType.text,
+        openText: '开',
+        closeText: '关',
+        thumbContentOnFont: 16,
+        thumbContentOffFont: 10,
+      ),
+      title: '基础开关',
+    );
+  }

--- a/tdesign-component/example/lib/page/td_switch_page.dart
+++ b/tdesign-component/example/lib/page/td_switch_page.dart
@@ -20,34 +20,36 @@ class TDSwitchPageState extends State<TDSwitchPage> {
   @override
   Widget build(BuildContext context) {
     var current = ExamplePage(
-        title: tdTitle(),
-        exampleCodeGroup: 'switch',
-        desc: '用于控制某个功能的开启和关闭。',
-        children: [
-          ExampleModule(
-            title: '组件类型',
-            children: [
-              ExampleItem(desc: '基础开关', builder: _buildSwitchWithBase),
-              ExampleItem(desc: '带描述开关', builder: _buildSwitchWithText),
-              ExampleItem(builder: _buildSwitchWithIcon),
-              ExampleItem(desc: '自定义颜色开关', builder: _buildSwitchWithColor),
-            ],
-          ),
-          ExampleModule(title: '组件状态', children: [
-            ExampleItem(desc: '加载状态', builder: _buildSwitchWithLoadingOff),
-            ExampleItem(builder: _buildSwitchWithLoadingOn),
-            ExampleItem(desc: '禁用状态', builder: _buildSwitchWithDisableOff),
-            ExampleItem(builder: _buildSwitchWithDisableOn),
-          ]),
-          ExampleModule(title: '组件样式', children: [
-            ExampleItem(desc: '开关尺寸', builder: _buildSwitchWithSizeLarge),
-            ExampleItem(builder: _buildSwitchWithSizeMed),
-            ExampleItem(builder: _buildSwitchWithSizeSmall),
-          ]),
-        ],
-    test: [
-      ExampleItem(desc: '自定义开关文案-通常只支持一个字符,超出部分无法展示', builder: _customText),
-    ],);
+      title: tdTitle(),
+      exampleCodeGroup: 'switch',
+      desc: '用于控制某个功能的开启和关闭。',
+      children: [
+        ExampleModule(
+          title: '组件类型',
+          children: [
+            ExampleItem(desc: '基础开关', builder: _buildSwitchWithBase),
+            ExampleItem(desc: '带描述开关', builder: _buildSwitchWithText),
+            ExampleItem(builder: _buildSwitchWithIcon),
+            ExampleItem(desc: '自定义颜色开关', builder: _buildSwitchWithColor),
+          ],
+        ),
+        ExampleModule(title: '组件状态', children: [
+          ExampleItem(desc: '加载状态', builder: _buildSwitchWithLoadingOff),
+          ExampleItem(builder: _buildSwitchWithLoadingOn),
+          ExampleItem(desc: '禁用状态', builder: _buildSwitchWithDisableOff),
+          ExampleItem(builder: _buildSwitchWithDisableOn),
+        ]),
+        ExampleModule(title: '组件样式', children: [
+          ExampleItem(desc: '开关尺寸', builder: _buildSwitchWithSizeLarge),
+          ExampleItem(builder: _buildSwitchWithSizeMed),
+          ExampleItem(builder: _buildSwitchWithSizeSmall),
+        ]),
+      ],
+      test: [
+        ExampleItem(desc: '自定义开关文案-通常只支持一个字符,超出部分无法展示', builder: _customText),
+        ExampleItem(desc: '自定义带文字开关的字体大小', builder: _customTextFont),
+      ],
+    );
     return current;
   }
 
@@ -291,6 +293,21 @@ class TDSwitchPageState extends State<TDSwitchPage> {
         type: TDSwitchType.text,
         openText: '1111',
         closeText: '—',
+      ),
+      title: '基础开关',
+    );
+  }
+
+  @Demo(group: 'switch')
+  Widget _customTextFont(BuildContext context) {
+    return _buildItem(
+      context,
+      const TDSwitch(
+        type: TDSwitchType.text,
+        openText: '开',
+        closeText: '关',
+        thumbContentOnFont: 16,
+        thumbContentOffFont: 10,
       ),
       title: '基础开关',
     );

--- a/tdesign-component/example/lib/page/td_switch_page.dart
+++ b/tdesign-component/example/lib/page/td_switch_page.dart
@@ -306,8 +306,10 @@ class TDSwitchPageState extends State<TDSwitchPage> {
         type: TDSwitchType.text,
         openText: '开',
         closeText: '关',
-        thumbContentOnFont: 16,
-        thumbContentOffFont: 10,
+        thumbContentOffColor: Colors.red,
+        thumbContentOnColor: Colors.green,
+        thumbContentOnFont: TextStyle(fontSize: 18),
+        thumbContentOffFont: TextStyle(fontSize: 12),
       ),
       title: '基础开关',
     );

--- a/tdesign-component/lib/src/components/switch/td_switch.dart
+++ b/tdesign-component/lib/src/components/switch/td_switch.dart
@@ -24,9 +24,11 @@ class TDSwitch extends StatefulWidget {
     this.trackOffColor,
     this.thumbContentOnColor,
     this.thumbContentOffColor,
+    this.thumbContentOnFont,
+    this.thumbContentOffFont,
     this.onChanged,
     this.openText,
-     this.closeText,
+    this.closeText,
   }) : super(key: key);
 
   /// 是否可点击
@@ -46,6 +48,12 @@ class TDSwitch extends StatefulWidget {
 
   /// 关闭时ThumbView的颜色
   final Color? thumbContentOffColor;
+
+  /// 开启时ThumbView的字体大小
+  final double? thumbContentOnFont;
+
+  /// 关闭时ThumbView的字体大小
+  final double? thumbContentOffFont;
 
   /// 尺寸：大、中、小
   final TDSwitchSize? size;
@@ -86,11 +94,16 @@ class TDSwitchState extends State<TDSwitch> {
   @override
   Widget build(BuildContext context) {
     final theme = TDTheme.of(context);
+    print(theme);
     final switchEnable = widget.enable && widget.type != TDSwitchType.loading;
     final trackOnColor = widget.trackOnColor ?? theme.brandColor7;
     final trackOffColor = widget.trackOffColor ?? theme.grayColor4;
-    final thumbContentOnColor = widget.thumbContentOnColor ?? theme.brandNormalColor;
-    final thumbContentOffColor = widget.thumbContentOffColor ?? theme.fontGyColor4;
+    final thumbContentOnColor =
+        widget.thumbContentOnColor ?? theme.brandNormalColor;
+    final thumbContentOffColor =
+        widget.thumbContentOffColor ?? theme.fontGyColor4;
+    final thumbContentOnFont = widget.thumbContentOnFont ?? 14;
+    final thumbContentOffFont = widget.thumbContentOffFont ?? 14;
     Widget current = TDCupertinoSwitch(
       value: isOn,
       activeColor: trackOnColor,
@@ -103,7 +116,7 @@ class TDSwitchState extends State<TDSwitch> {
           setState(() {});
         }
       },
-      thumbView: _getThumbView(thumbContentOnColor, thumbContentOffColor),
+      thumbView: _getThumbView(thumbContentOnColor, thumbContentOffColor,thumbContentOnFont, thumbContentOffFont),
     );
     if (!switchEnable) {
       current = Opacity(
@@ -150,20 +163,28 @@ class TDSwitchState extends State<TDSwitch> {
     }
   }
 
-  Widget? _getThumbView(Color thumbContentOnColor, Color thumbContentOffColor) {
+  Widget? _getThumbView(Color thumbContentOnColor, Color thumbContentOffColor, double thumbContentOnFont, double thumbContentOffFont) {
     switch (widget.type) {
       case TDSwitchType.text:
         return Stack(
-          children: [Container(
-            alignment: Alignment.center,
-            width: 16,
-            child: TDText(
-              isOn ? (widget.openText ?? context.resource.open) : (widget.closeText ?? context.resource.close),
-              style: TextStyle(color: isOn ? thumbContentOnColor : thumbContentOffColor, fontSize: 14),
-              forceVerticalCenter: true,
-              maxLines: 1,
-            ),
-          )],
+          children: [
+            Container(
+              alignment: Alignment.center,
+              width: 16,
+              child: TDText(
+                isOn
+                    ? (widget.openText ?? context.resource.open)
+                    : (widget.closeText ?? context.resource.close),
+                style: TextStyle(
+                    color: isOn ? thumbContentOnColor : thumbContentOffColor,
+                    fontSize: isOn
+                        ? thumbContentOnFont
+                        : thumbContentOffFont),
+                forceVerticalCenter: true,
+                maxLines: 1,
+              ),
+            )
+          ],
         );
       case TDSwitchType.loading:
         return Container(
@@ -178,7 +199,8 @@ class TDSwitchState extends State<TDSwitch> {
         return Container(
           alignment: Alignment.centerLeft,
           child: Icon(isOn ? TDIcons.check : TDIcons.close,
-              size: 16, color: isOn ? thumbContentOnColor : thumbContentOffColor),
+              size: 16,
+              color: isOn ? thumbContentOnColor : thumbContentOffColor),
         );
       case TDSwitchType.fill:
       default:

--- a/tdesign-component/lib/src/components/switch/td_switch.dart
+++ b/tdesign-component/lib/src/components/switch/td_switch.dart
@@ -94,7 +94,6 @@ class TDSwitchState extends State<TDSwitch> {
   @override
   Widget build(BuildContext context) {
     final theme = TDTheme.of(context);
-    print(theme);
     final switchEnable = widget.enable && widget.type != TDSwitchType.loading;
     final trackOnColor = widget.trackOnColor ?? theme.brandColor7;
     final trackOffColor = widget.trackOffColor ?? theme.grayColor4;

--- a/tdesign-component/lib/src/components/switch/td_switch.dart
+++ b/tdesign-component/lib/src/components/switch/td_switch.dart
@@ -49,11 +49,11 @@ class TDSwitch extends StatefulWidget {
   /// 关闭时ThumbView的颜色
   final Color? thumbContentOffColor;
 
-  /// 开启时ThumbView的字体大小
-  final double? thumbContentOnFont;
+  /// 开启时ThumbView的字体样式
+  final TextStyle? thumbContentOnFont;
 
-  /// 关闭时ThumbView的字体大小
-  final double? thumbContentOffFont;
+  /// 关闭时ThumbView的字体样式
+  final TextStyle? thumbContentOffFont;
 
   /// 尺寸：大、中、小
   final TDSwitchSize? size;
@@ -101,8 +101,8 @@ class TDSwitchState extends State<TDSwitch> {
         widget.thumbContentOnColor ?? theme.brandNormalColor;
     final thumbContentOffColor =
         widget.thumbContentOffColor ?? theme.fontGyColor4;
-    final thumbContentOnFont = widget.thumbContentOnFont ?? 14;
-    final thumbContentOffFont = widget.thumbContentOffFont ?? 14;
+    final thumbContentOnFont = widget.thumbContentOnFont ?? const TextStyle(fontSize: 14);
+    final thumbContentOffFont = widget.thumbContentOffFont ?? const TextStyle(fontSize: 14);
     Widget current = TDCupertinoSwitch(
       value: isOn,
       activeColor: trackOnColor,
@@ -162,7 +162,7 @@ class TDSwitchState extends State<TDSwitch> {
     }
   }
 
-  Widget? _getThumbView(Color thumbContentOnColor, Color thumbContentOffColor, double thumbContentOnFont, double thumbContentOffFont) {
+  Widget? _getThumbView(Color thumbContentOnColor, Color thumbContentOffColor, TextStyle thumbContentOnFont, TextStyle thumbContentOffFont) {
     switch (widget.type) {
       case TDSwitchType.text:
         return Stack(
@@ -174,13 +174,10 @@ class TDSwitchState extends State<TDSwitch> {
                 isOn
                     ? (widget.openText ?? context.resource.open)
                     : (widget.closeText ?? context.resource.close),
-                style: TextStyle(
-                    color: isOn ? thumbContentOnColor : thumbContentOffColor,
-                    fontSize: isOn
-                        ? thumbContentOnFont
-                        : thumbContentOffFont),
+                textColor: isOn ? thumbContentOnColor : thumbContentOffColor,
                 forceVerticalCenter: true,
                 maxLines: 1,
+                style: isOn ? thumbContentOnFont : thumbContentOffFont,
               ),
             )
           ],


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-flutter/issues/208

### 💡 需求背景和解决方案

问题：Switch组件支持自定义文字，但当前字体大小是固定的，用户如果想把文字改小点，不支持修改。
任务：请参考Switch组件的thumbContentOnColor属性，增加thumbContentOnFont和thumbContentOffFont，实现修改字体大小的功能，并在Switch示例页的“单元测试”栏目下，增加使用示例。

实现自定义开关前自定义大小以及demo样例

![image](https://github.com/Tencent/tdesign-flutter/assets/92632534/7f1194de-a45e-4498-b64e-cbdd704c5c98)
![image](https://github.com/Tencent/tdesign-flutter/assets/92632534/3484ebee-2814-4d66-a2c1-b4f24e39f398)

api文档以及代码样例
![image](https://github.com/Tencent/tdesign-flutter/assets/92632534/c9d183db-6c89-445e-a45c-fb2fd335a313)
![image](https://github.com/Tencent/tdesign-flutter/assets/92632534/84bda858-a93c-4cc6-a3cd-559d59bff12c)

### 📝 更新日志


- feat(TDSwitch): 添加自定义“开/关”字体大小

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
