### PR TITLE
Slider演示代码拆分

### DIFF
--- a/tdesign-component/example/lib/page/td_slider_page.dart
+++ b/tdesign-component/example/lib/page/td_slider_page.dart
@@ -32,10 +32,17 @@ class _TDSliderPageState extends State<TDSliderPage> {
             ExampleItem(desc: '带刻度双游标滑块', builder: _buildDoubleHandleWithScale),
           ]),
           ExampleModule(title: '组件状态', children: [
-            ExampleItem(desc: '禁用状态', builder: _buildDisable),
+            ExampleItem(desc: '禁用状态', builder: _buildDisableSingleHandle),
+            ExampleItem(builder: _buildDisableDoubleHandleWithNumber),
+            ExampleItem(builder: _buildDisableDoubleHandleWithScale),
           ]),
           ExampleModule(title: '特殊样式', children: [
-            ExampleItem(desc: '胶囊型滑块', builder: _buildCapsule),
+            ExampleItem(desc: '胶囊型滑块', builder: _buildCapsuleSingleHandleWithNumber),
+            ExampleItem(builder: _buildCapsuleDoubleHandle),
+            ExampleItem(builder: _buildCapsuleSingleHandle),
+            ExampleItem(builder: _buildCapsuleDoubleHandleWithNumber),
+            ExampleItem(builder: _buildCapsuleSingleHandleWithScale),
+            ExampleItem(builder: _buildCapsuleDoubleHandleWithScale),
           ]),
         ]);
   }
@@ -48,7 +55,6 @@ class _TDSliderPageState extends State<TDSliderPage> {
         max: 100,
       ),
       value: 10,
-      // divisions: 5,
       onChanged: (value) {},
     );
   }
@@ -61,7 +67,6 @@ class _TDSliderPageState extends State<TDSliderPage> {
         max: 100,
       ),
       value: const RangeValues(10, 60),
-      // divisions: 5,
       onChanged: (value) {},
     );
   }
@@ -78,7 +83,6 @@ class _TDSliderPageState extends State<TDSliderPage> {
       value: 10,
       leftLabel: '0',
       rightLabel: '100',
-      // divisions: 5,
       onChanged: (value) {},
     );
   }
@@ -95,7 +99,6 @@ class _TDSliderPageState extends State<TDSliderPage> {
       leftLabel: '0',
       rightLabel: '100',
       value: const RangeValues(40, 60),
-      // divisions: 5,
       onChanged: (value) {},
     );
   }
@@ -111,7 +114,6 @@ class _TDSliderPageState extends State<TDSliderPage> {
         scaleFormatter: (value) => value.toInt().toString(),
       ),
       value: 60,
-      // divisions: 5,
       onChanged: (value) {},
     );
   }
@@ -127,153 +129,143 @@ class _TDSliderPageState extends State<TDSliderPage> {
         scaleFormatter: (value) => value.toInt().toString(),
       ),
       value: const RangeValues(40, 70),
-      // divisions: 5,
       onChanged: (value) {},
     );
   }
 
   @Demo(group: 'slider')
-  Widget _buildDisable(BuildContext context) {
-    return Column(
-      children: [
-        TDSlider(
-          sliderThemeData: TDSliderThemeData(
-            min: 0,
-            max: 100,
-          ),
-          value: 40,
-          leftLabel: '0',
-          rightLabel: '100',
-        ),
-        const SizedBox(
-          height: 16,
-        ),
-        TDRangeSlider(
-          sliderThemeData: TDSliderThemeData(
-            min: 0,
-            max: 100,
-            showThumbValue: true,
-            scaleFormatter: (value) => value.toInt().toString(),
-          ),
-          value: const RangeValues(20, 60),
-          leftLabel: '0',
-          rightLabel: '100',
-        ),
-        const SizedBox(
-          height: 16,
-        ),
-        TDRangeSlider(
-          sliderThemeData: TDSliderThemeData(
-            showScaleValue: true,
-            divisions: 5,
-            min: 0,
-            max: 100,
-            scaleFormatter: (value) => value.toInt().toString(),
-          ),
-          value: const RangeValues(20, 60),
-        ),
-      ],
+  Widget _buildDisableSingleHandle(BuildContext context) {
+    return TDSlider(
+      sliderThemeData: TDSliderThemeData(
+        min: 0,
+        max: 100,
+      ),
+      leftLabel: '0',
+      rightLabel: '100',
+      value: 40,
     );
   }
 
   @Demo(group: 'slider')
-  Widget _buildCapsule(BuildContext context) {
-    return Column(
-      children: [
-        TDSlider(
-          sliderThemeData: TDSliderThemeData.capsule(
-            showThumbValue: true,
-            min: 0,
-            max: 100,
-            scaleFormatter: (value) => value.toInt().toString(),
-          ),
-          value: 40,
-          // divisions: 5,
-          onChanged: (value) {},
-        ),
-        const SizedBox(
-          height: 16,
-        ),
-        TDRangeSlider(
-          sliderThemeData: TDSliderThemeData.capsule(
-            min: 0,
-            max: 100,
-            scaleFormatter: (value) => value.toInt().toString(),
-          ),
-          value: const RangeValues(20, 60),
-          // divisions: 5,
-          onChanged: (value) {},
-        ),
-        const SizedBox(
-          height: 16,
-        ),
-        TDSlider(
-          sliderThemeData: TDSliderThemeData.capsule(
-            min: 0,
-            max: 100,
-            scaleFormatter: (value) => value.toInt().toString(),
-          ),
-          leftLabel: '0',
-          rightLabel: '100',
-          value: 40,
-          // divisions: 5,
-          onChanged: (value) {},
-        ),
-        const SizedBox(
-          height: 16,
-        ),
-        TDRangeSlider(
-          sliderThemeData: TDSliderThemeData.capsule(
-            min: 0,
-            max: 100,
-            showThumbValue: true,
-            scaleFormatter: (value) => value.toInt().toString(),
-          ),
-          value: const RangeValues(20, 60),
-          leftLabel: '0',
-          rightLabel: '100',
-          // divisions: 5,
-          onChanged: (value) {},
-        ),
-        const SizedBox(
-          height: 16,
-        ),
-        TDSlider(
-          sliderThemeData: TDSliderThemeData.capsule(
-            showScaleValue: true,
-            divisions: 5,
-            min: 0,
-            max: 100,
-            scaleFormatter: (value) => value.toInt().toString(),
-          )..updateSliderThemeData((data) => data.copyWith(
-                activeTickMarkColor: const Color(0xFFE7E7E7),
-                inactiveTickMarkColor: const Color(0xFFE7E7E7),
-              )),
-          value: 60,
-          // divisions: 5,
-          onChanged: (value) {},
-        ),
-        const SizedBox(
-          height: 16,
-        ),
-        TDRangeSlider(
-          sliderThemeData: TDSliderThemeData.capsule(
-            showScaleValue: true,
-            divisions: 5,
-            min: 0,
-            max: 100,
-            scaleFormatter: (value) => value.toInt().toString(),
-          )
-            ..updateSliderThemeData((data) =>
-                data.copyWith(
-                  activeTickMarkColor: const Color(0xFFE7E7E7),
-                  inactiveTickMarkColor: const Color(0xFFE7E7E7),
-                )),
-          value: const RangeValues(20, 60),
-          // divisions: 5,
-          onChanged: (value) {},
-        )
-      ],
+  Widget _buildDisableDoubleHandleWithNumber(BuildContext context) {
+    return TDRangeSlider(
+      sliderThemeData: TDSliderThemeData(
+        showThumbValue: true,
+        min: 0,
+        max: 100,
+        scaleFormatter: (value) => value.toInt().toString(),
+      ),
+      leftLabel: '0',
+      rightLabel: '100',
+      value: const RangeValues(20, 60),
+    );
+  }
+
+  @Demo(group: 'slider')
+  Widget _buildDisableDoubleHandleWithScale(BuildContext context) {
+    return TDRangeSlider(
+      sliderThemeData: TDSliderThemeData(
+        showScaleValue: true,
+        divisions: 5,
+        min: 0,
+        max: 100,
+        scaleFormatter: (value) => value.toInt().toString(),
+      ),
+      value: const RangeValues(20, 60),
+    );
+  }
+  
+  @Demo(group: 'slider')
+  Widget _buildCapsuleSingleHandleWithNumber(BuildContext context) {
+    return TDSlider(
+      sliderThemeData: TDSliderThemeData.capsule(
+        showThumbValue: true,
+        min: 0,
+        max: 100,
+        scaleFormatter: (value) => value.toInt().toString(),
+      ),
+      value: 40,
+      onChanged: (value) {},
+    );
+  }
+
+  @Demo(group: 'slider')
+  Widget _buildCapsuleDoubleHandle(BuildContext context) {
+    return TDRangeSlider(
+      sliderThemeData: TDSliderThemeData.capsule(
+        min: 0,
+        max: 100,
+        scaleFormatter: (value) => value.toInt().toString(),
+      ),
+      value: const RangeValues(20, 60),
+      onChanged: (value) {},
+    );
+  }
+
+  @Demo(group: 'slider')
+  Widget _buildCapsuleSingleHandle(BuildContext context) {
+    return TDSlider(
+      sliderThemeData: TDSliderThemeData.capsule(
+        min: 0,
+        max: 100,
+        scaleFormatter: (value) => value.toInt().toString(),
+      ),
+      leftLabel: '0',
+      rightLabel: '100',
+      value: 40,
+      onChanged: (value) {},
+    );
+  }
+
+  @Demo(group: 'slider')
+  Widget _buildCapsuleDoubleHandleWithNumber(BuildContext context) {
+    return TDRangeSlider(
+      sliderThemeData: TDSliderThemeData.capsule(
+        showThumbValue: true,
+        min: 0,
+        max: 100,
+        scaleFormatter: (value) => value.toInt().toString(),
+      ),
+      leftLabel: '0',
+      rightLabel: '100',
+      value: const RangeValues(20, 60),
+      onChanged: (value) {},
+    );
+  }
+
+  @Demo(group: 'slider')
+  Widget _buildCapsuleSingleHandleWithScale(BuildContext context) {
+    return TDSlider(
+      sliderThemeData: TDSliderThemeData.capsule(
+        showScaleValue: true,
+        divisions: 5,
+        min: 0,
+        max: 100,
+        scaleFormatter: (value) => value.toInt().toString(),
+      )..updateSliderThemeData((data) => data.copyWith(
+           activeTickMarkColor: const Color(0xFFE7E7E7),
+           inactiveTickMarkColor: const Color(0xFFE7E7E7),
+      )),
+      value: 60,
+      onChanged: (value) {},
+    );
+  }
+
+  @Demo(group: 'slider')
+  Widget _buildCapsuleDoubleHandleWithScale(BuildContext context) {
+    return TDRangeSlider(
+      sliderThemeData: TDSliderThemeData.capsule(
+        showScaleValue: true,
+        divisions: 5,
+        min: 0,
+        max: 100,
+        scaleFormatter: (value) => value.toInt().toString(),
+      )..updateSliderThemeData((data) => data.copyWith(
+           activeTickMarkColor: const Color(0xFFE7E7E7),
+           inactiveTickMarkColor: const Color(0xFFE7E7E7),
+      )),
+      value: const RangeValues(20, 60),
+      onChanged: (value) {},
     );
   }
 }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-flutter/issues/205

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
问题：Slider的“组件状态”和“特殊样式”下面，多个演示组件使用同一份演示代码，演示代码太长，可读性不高。

解决：
- 拆分禁用状态示例代码的`_buildDisable`成`_buildDisableSingleHandle`、`_buildDisableDoubleHandleWithNumber`、`_buildDisableDoubleHandleWithScale`；
- 拆分胶囊型滑块示例代码的`_buildCapsule`成`_buildCapsuleSingleHandleWithNumber`、`_buildCapsuleDoubleHandle`、`_buildCapsuleSingleHandle`、`_buildCapsuleDoubleHandleWithNumber`、`_buildCapsuleSingleHandleWithScale`、`_buildCapsuleDoubleHandleWithScale`。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
