### PR TITLE
fix(td_button): 修复设置shape为square或circle时出现overflow

### DIFF
--- a/tdesign-component/lib/src/components/button/td_button.dart
+++ b/tdesign-component/lib/src/components/button/td_button.dart
@@ -363,19 +363,19 @@ class _TDButtonState extends State<TDButton> {
     double verticalPadding;
     switch (widget.size) {
       case TDButtonSize.large:
-        horizontalPadding = equalSide ? 12 : 20;
+        horizontalPadding = equalSide ? 10 : 20;
         verticalPadding = 12;
         break;
       case TDButtonSize.medium:
-        horizontalPadding = equalSide ? 10 : 16;
+        horizontalPadding = equalSide ? 8 : 16;
         verticalPadding = equalSide ? 10 : 8;
         break;
       case TDButtonSize.small:
-        horizontalPadding = equalSide ? 7 : 12;
+        horizontalPadding = equalSide ? 6 : 12;
         verticalPadding = equalSide ? 7 : 5;
         break;
       case TDButtonSize.extraSmall:
-        horizontalPadding = equalSide ? 5 : 8;
+        horizontalPadding = equalSide ? 4 : 8;
         verticalPadding = equalSide ? 5 : 3;
         break;
     }

--- a/tdesign-component/lib/src/components/button/td_button.dart
+++ b/tdesign-component/lib/src/components/button/td_button.dart
@@ -375,7 +375,7 @@ class _TDButtonState extends State<TDButton> {
         verticalPadding = equalSide ? 7 : 5;
         break;
       case TDButtonSize.extraSmall:
-        horizontalPadding = equalSide ? 7 : 8;
+        horizontalPadding = equalSide ? 5 : 8;
         verticalPadding = equalSide ? 5 : 3;
         break;
     }

--- a/tdesign-component/lib/src/components/button/td_button.dart
+++ b/tdesign-component/lib/src/components/button/td_button.dart
@@ -338,11 +338,11 @@ class _TDButtonState extends State<TDButton> {
       case TDButtonSize.large:
         return 24;
       case TDButtonSize.medium:
-        return 22;
+        return 20;
       case TDButtonSize.small:
-        return 20;
+        return 18;
       case TDButtonSize.extraSmall:
-        return 20;
+        return 14;
     }
   }
 
@@ -363,19 +363,19 @@ class _TDButtonState extends State<TDButton> {
     double verticalPadding;
     switch (widget.size) {
       case TDButtonSize.large:
-        horizontalPadding = equalSide ? 10 : 20;
+        horizontalPadding = equalSide ? 12 : 20;
         verticalPadding = 12;
         break;
       case TDButtonSize.medium:
-        horizontalPadding = equalSide ? 8 : 16;
+        horizontalPadding = equalSide ? 10 : 16;
         verticalPadding = equalSide ? 10 : 8;
         break;
       case TDButtonSize.small:
-        horizontalPadding = equalSide ? 6 : 12;
+        horizontalPadding = equalSide ? 7 : 12;
         verticalPadding = equalSide ? 7 : 5;
         break;
       case TDButtonSize.extraSmall:
-        horizontalPadding = equalSide ? 4 : 8;
+        horizontalPadding = equalSide ? 7 : 8;
         verticalPadding = equalSide ? 5 : 3;
         break;
     }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#254 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

修复td_button设置shape为square或circle时出现overflow right 2px

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(td_button): 修复设置shape为square或circle时出现overflow

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
