### PR TITLE
Feature/td search bar新增Action和onActionClick属性

### DIFF
--- a/tdesign-component/example/assets/api/search_api.md
+++ b/tdesign-component/example/assets/api/search_api.md
@@ -2,19 +2,21 @@
 ### TDSearchBar
 #### 默认构造方法
 
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| key |  | - |  |
-| placeHolder | String? | - | 预设文案 |
-| style | TDSearchStyle? | TDSearchStyle.square | 样式 |
-| alignment | TDSearchAlignment? | TDSearchAlignment.left | 对齐方式，居中或这头部对齐 |
-| onTextChanged | TDSearchBarEvent? | - | 文字改变回调 |
-| onSubmitted | TDSearchBarEvent? | - | 提交回调 |
-| onEditComplete | TDSearchBarCallBack? | - | 编辑完成回调 |
-| autoHeight | bool | false | 是否自动计算高度 |
-| padding | EdgeInsets | const EdgeInsets.fromLTRB(16, 8, 16, 8) | 内部填充 |
-| autoFocus | bool | false | 是否自动获取焦点 |
-| mediumStyle | bool | false | 是否在导航栏中的样式 |
-| needCancel | bool | false | 是否需要取消按钮 |
-| controller | TextEditingController? | - | 控制器 |
-| backgroundColor | Color? | Colors.white | 背景颜色 |
+| 参数              | 类型                     | 默认值                                     | 说明            |
+|-----------------|------------------------|-----------------------------------------|---------------|
+| key             |                        | -                                       |               |
+| placeHolder     | String?                | -                                       | 预设文案          |
+| style           | TDSearchStyle?         | TDSearchStyle.square                    | 样式            |
+| alignment       | TDSearchAlignment?     | TDSearchAlignment.left                  | 对齐方式，居中或这头部对齐 |
+| onTextChanged   | TDSearchBarEvent?      | -                                       | 文字改变回调        |
+| onSubmitted     | TDSearchBarEvent?      | -                                       | 提交回调          |
+| onEditComplete  | TDSearchBarCallBack?   | -                                       | 编辑完成回调        |
+| autoHeight      | bool                   | false                                   | 是否自动计算高度      |
+| padding         | EdgeInsets             | const EdgeInsets.fromLTRB(16, 8, 16, 8) | 内部填充          |
+| autoFocus       | bool                   | false                                   | 是否自动获取焦点      |
+| mediumStyle     | bool                   | false                                   | 是否在导航栏中的样式    |
+| needCancel      | bool                   | false                                   | 是否需要取消按钮      |
+| action          | String                 | ‘’                                      | 右侧操作按钮文字      |
+| onActionClick   | TDSearchBarEvent?      | -                                       | 右侧操作按钮点击回调    |
+| controller      | TextEditingController? | -                                       | 控制器           |
+| backgroundColor | Color?                 | Colors.white                            | 背景颜色          |

--- a/tdesign-component/example/assets/code/search._buildSearchBarWithAction.txt
+++ b/tdesign-component/example/assets/code/search._buildSearchBarWithAction.txt
@@ -1,0 +1,30 @@
+
+  Widget _buildSearchBarWithAction(BuildContext context) {
+    return Column(
+      children: [
+        TDSearchBar(
+          placeHolder: '搜索预设文案',
+          alignment: TDSearchAlignment.left,
+          action: '搜索',
+          onActionClick: (String text) {
+            setState(() {
+              searchText = text;
+            });
+          },
+          onTextChanged: (String text) {
+            setState(() {
+              inputText = text;
+            });
+          },
+        ),
+        const SizedBox(height: 10,),
+        Container(
+          padding: const EdgeInsets.only(left: 15),
+          alignment: Alignment.centerLeft,
+          child: TDText(
+            '搜索框输入的内容：${searchText ?? ''}',
+          ),
+        )
+      ],
+    );
+  }

--- a/tdesign-component/example/lib/page/td_search_bar_page.dart
+++ b/tdesign-component/example/lib/page/td_search_bar_page.dart
@@ -13,6 +13,7 @@ class TDSearchBarPage extends StatefulWidget {
 
 class _TDSearchBarPageState extends State<TDSearchBarPage> {
   String? inputText;
+  String? searchText;
 
   @override
   Widget build(BuildContext context) {
@@ -27,6 +28,8 @@ class _TDSearchBarPageState extends State<TDSearchBarPage> {
             children: [
               ExampleItem(desc: '基础搜索框', builder: _buildDefaultSearchBar),
               ExampleItem(desc: '获取焦点后显示取消按钮', builder: _buildFocusSearchBar),
+              ExampleItem(
+                  desc: '获取焦点后显示自定义操作按钮', builder: _buildSearchBarWithAction),
             ],
           ),
           ExampleModule(title: '组件样式', children: [
@@ -113,6 +116,37 @@ class _TDSearchBarPageState extends State<TDSearchBarPage> {
           inputText = text;
         });
       },
+    );
+  }
+
+  @Demo(group: 'search')
+  Widget _buildSearchBarWithAction(BuildContext context) {
+    return Column(
+      children: [
+        TDSearchBar(
+          placeHolder: '搜索预设文案',
+          alignment: TDSearchAlignment.left,
+          action: '搜索',
+          onActionClick: (String text) {
+            setState(() {
+              searchText = text;
+            });
+          },
+          onTextChanged: (String text) {
+            setState(() {
+              inputText = text;
+            });
+          },
+        ),
+        const SizedBox(height: 10,),
+        Container(
+          padding: const EdgeInsets.only(left: 15),
+          alignment: Alignment.centerLeft,
+          child: TDText(
+            '搜索框输入的内容：${searchText ?? ''}',
+          ),
+        )
+      ],
     );
   }
 }

--- a/tdesign-component/example/lib/page/td_search_bar_page.dart
+++ b/tdesign-component/example/lib/page/td_search_bar_page.dart
@@ -28,15 +28,16 @@ class _TDSearchBarPageState extends State<TDSearchBarPage> {
             children: [
               ExampleItem(desc: '基础搜索框', builder: _buildDefaultSearchBar),
               ExampleItem(desc: '获取焦点后显示取消按钮', builder: _buildFocusSearchBar),
-              ExampleItem(
-                  desc: '获取焦点后显示自定义操作按钮', builder: _buildSearchBarWithAction),
             ],
           ),
           ExampleModule(title: '组件样式', children: [
             ExampleItem(desc: '搜索框形状', builder: _buildSearchBarWithShape),
             ExampleItem(desc: '默认状态其他对齐方式', builder: _buildCenterSearchBar),
-          ])
-        ]);
+          ]),
+        ],
+      test: [
+        ExampleItem(desc: '获取焦点后显示自定义操作按钮', builder: _buildSearchBarWithAction),
+      ],);
   }
 
   @Demo(group: 'search')

--- a/tdesign-component/lib/src/components/search/td_search_bar.dart
+++ b/tdesign-component/lib/src/components/search/td_search_bar.dart
@@ -38,6 +38,8 @@ class TDSearchBar extends StatefulWidget {
     this.needCancel = false,
     this.controller,
     this.backgroundColor = Colors.white,
+    this.action = '',
+    this.onActionClick,
   }) : super(key: key);
 
   /// 预设文案
@@ -78,6 +80,12 @@ class TDSearchBar extends StatefulWidget {
 
   /// 编辑完成回调
   final TDSearchBarCallBack? onEditComplete;
+
+  /// 自定义操作文字
+  final String action;
+
+  /// 自定义操作回调
+  final TDSearchBarEvent? onActionClick;
 
   @override
   State<StatefulWidget> createState() => _TDSearchBarState();
@@ -169,6 +177,21 @@ class _TDSearchBarState extends State<TDSearchBar>
         : TDTheme.of(context).fontBodyLarge;
   }
 
+  Widget actionBtn(BuildContext context, String? text, {String? action, TDSearchBarEvent? onActionClick} ){
+    return GestureDetector(
+      onTap: (){
+        onActionClick!(text??'');
+      },
+      child: Container(
+        padding: const EdgeInsets.only(left: 16),
+        child: Text(action!,
+            style: TextStyle(
+                fontSize: getSize(context)?.size,
+                color: TDTheme.of(context).brandNormalColor)),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -255,37 +278,44 @@ class _TDSearchBarState extends State<TDSearchBar>
                 ),
               ),
             ),
-            Offstage(
-              offstage: cancelBtnHide || !widget.needCancel,
-              child: GestureDetector(
-                onTap: () {
-                  _cleanInputText();
-                  if (widget.onTextChanged != null) {
-                    widget.onTextChanged!('');
-                  }
-                  if (_animation == null) {
-                    focusNode.unfocus();
-                    setState(() {
-                      _status = _TDSearchBarStatus.unFocus;
-                    });
-                    return;
-                  }
-                  setState(() {
-                    _status = _TDSearchBarStatus.animatingToUnFocus;
-                  });
-                  focusNode.unfocus();
-                  _animationController.reverse(
-                      from: _animationController.upperBound);
-                },
-                child: Container(
-                  padding: const EdgeInsets.only(left: 16),
-                  child: Text(context.resource.cancel,
-                      style: TextStyle(
-                          fontSize: getSize(context)?.size,
-                          color: TDTheme.of(context).brandNormalColor)),
-                ),
-              ),
-            ),
+            widget.action.isNotEmpty
+                ? actionBtn(
+                    context,
+                    controller.text,
+                    action: widget.action,
+                    onActionClick: widget.onActionClick ?? (String text) {},
+                  )
+                : Offstage(
+                    offstage: cancelBtnHide || !widget.needCancel,
+                    child: GestureDetector(
+                      onTap: () {
+                        _cleanInputText();
+                        if (widget.onTextChanged != null) {
+                          widget.onTextChanged!('');
+                        }
+                        if (_animation == null) {
+                          focusNode.unfocus();
+                          setState(() {
+                            _status = _TDSearchBarStatus.unFocus;
+                          });
+                          return;
+                        }
+                        setState(() {
+                          _status = _TDSearchBarStatus.animatingToUnFocus;
+                        });
+                        focusNode.unfocus();
+                        _animationController.reverse(
+                            from: _animationController.upperBound);
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.only(left: 16),
+                        child: Text(context.resource.cancel,
+                            style: TextStyle(
+                                fontSize: getSize(context)?.size,
+                                color: TDTheme.of(context).brandNormalColor)),
+                      ),
+                    ),
+                  ),
           ],
         ),
         Offstage(


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
#209 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
问题：Search组件不支持自定有右侧文字和文字的点击操作。

实现：在Search组件中添加以下两个属性
* Action：String类型，表示右侧显示的文字，默认为空串，为空串时不显示，且不影响其他属性；若设置了Action属性，needCancel属性将不会起作用，不会显示取消按钮。
* onActionClick：TDSearchBarEvent类型，表示右侧操作按钮点击后的回调，带有一个String参数，获取输入框中的文本。

实现效果：
* 未获取焦点时：
![image](https://github.com/user-attachments/assets/aed005c6-de5b-4ef7-aef6-e457a8a24963)
* 获取焦点后：
![image](https://github.com/user-attachments/assets/1b308959-ecac-41c4-8f95-dff302213684)
* 点击右侧操作按钮后：
![image](https://github.com/user-attachments/assets/b04d002a-45a4-4757-839e-a51d4a34fcb6)
* 示例代码：
![image](https://github.com/user-attachments/assets/f264b426-5a31-4ed6-9840-ca1d4b3105f6)


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(td_search_bar): 新增Action和onActionClick属性

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
