### PR TITLE
[Drawer]支持控制分割线显隐，支持自定义抽屉背景色，支持是否显示最后一个分割线

### DIFF
--- a/tdesign-component/example/lib/page/td_drawer_page.dart
+++ b/tdesign-component/example/lib/page/td_drawer_page.dart
@@ -81,7 +81,15 @@ class TDDrawerPage extends StatelessWidget {
               ),
             ]),
           ],
-          test: const [],
+          test: [
+            ExampleItem(
+              ignoreCode: true,
+              desc: '自定义背景色',
+              builder: (BuildContext context) {
+                return const CodeWrapper(builder: _buildColorSimple);
+              },
+            )
+          ],
         ));
   }
 }
@@ -178,6 +186,29 @@ Widget _buildBottomSimple(BuildContext context) {
           width: double.infinity,
           size: TDButtonSize.large,
         ),
+      );
+    },
+  );
+}
+
+@Demo(group: 'drawer')
+Widget _buildColorSimple(BuildContext context) {
+  var renderBox = navBarkey.currentContext?.findRenderObject() as RenderBox?;
+  return TDButton(
+    text: '自定义背景色',
+    isBlock: true,
+    type: TDButtonType.outline,
+    theme: TDButtonTheme.primary,
+    size: TDButtonSize.large,
+    onTap: () {
+      TDDrawer(
+        context,
+        visible: true,
+        drawerTop: renderBox?.size.height,
+        title: '标题',
+        backgroundColor: TDTheme.of(context).grayColor1,
+        placement: TDDrawerPlacement.right,
+        items: List.generate(10, (index) => TDDrawerItem(title: '菜单${_nums[index]}')).toList(),
       );
     },
   );

--- a/tdesign-component/lib/src/components/drawer/td_drawer.dart
+++ b/tdesign-component/lib/src/components/drawer/td_drawer.dart
@@ -32,6 +32,9 @@ class TDDrawer {
     this.drawerTop,
     this.style,
     this.hover = true,
+    this.backgroundColor,
+    this.bordered = true,
+    this.isShowLastBordered = true,
   }) {
     if (visible == true) {
       show();
@@ -83,6 +86,15 @@ class TDDrawer {
   /// 是否开启点击反馈
   final bool? hover;
 
+  /// 组件背景颜色
+  final Color? backgroundColor;
+
+  /// 是否显示边框
+  final bool? bordered;
+
+  /// 是否显示最后一行分割线
+  final bool? isShowLastBordered;
+
   static TDSlidePopupRoute? _drawerRoute;
 
   void show() {
@@ -112,6 +124,7 @@ class TDDrawer {
                   title: item.title,
                   leftIconWidget: item.icon,
                   hover: hover,
+                  bordered: bordered,
                   onClick: (cell) {
                     if (onItemClick == null) {
                       return;
@@ -124,7 +137,7 @@ class TDDrawer {
             .values
             .toList();
         return Container(
-          color: Colors.white,
+          color: backgroundColor ?? Colors.white,
           width: width ?? 280,
           height: double.infinity,
           child: Column(
@@ -135,7 +148,7 @@ class TDDrawer {
                   titleWidget: titleWidget,
                   style: cellStyle,
                   scrollable: true,
-                  isShowLastBordered: true,
+                  isShowLastBordered: isShowLastBordered,
                   cells: cells ?? [],
                 ),
               ),


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#274 ](https://github.com/Tencent/tdesign-flutter/issues/274)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Drawer): 支持控制分割线显隐，支持自定义抽屉背景色，支持控制显示最后一条分割线

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
