### PR TITLE
[Dialog]支持自定义内容边距和按钮

### DIFF
--- a/tdesign-component/example/lib/page/td_dialog_page.dart
+++ b/tdesign-component/example/lib/page/td_dialog_page.dart
@@ -68,6 +68,7 @@ class _TDDialogPageState extends State<TDDialogPage> {
       ExampleItem(builder: _customConfirmNormal),
       ExampleItem(builder: _customConfirmVertical),
       ExampleItem(builder: _customImageTop),
+      ExampleItem(desc: '自定义边距和按钮', builder: _customContentAndBtn)
     ],);
   }
 
@@ -732,6 +733,39 @@ class _TDDialogPageState extends State<TDDialogPage> {
           },
         );
       },
+    );
+  }
+
+  @Demo(group: 'dialog')
+  Widget _customContentAndBtn(BuildContext context) {
+    return TDButton(
+        text: '自定义边距和按钮',
+        size: TDButtonSize.large,
+        type: TDButtonType.outline,
+        theme: TDButtonTheme.primary,
+        onTap: () {
+          showGeneralDialog(
+            context: context,
+            pageBuilder: (BuildContext buildContext, Animation<double> animation,
+                Animation<double> secondaryAnimation) {
+              return TDConfirmDialog(
+                title: _dialogTitle,
+                content: _commonContent,
+                padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+                buttonWidget: Container(
+                  padding: const EdgeInsets.fromLTRB(0, 16, 0, 16),
+                  child: TDButton(
+                    text: '自定义按钮',
+                    theme: TDButtonTheme.primary,
+                    onTap: () {
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                ),
+              );
+            }
+          );
+        }
     );
   }
 }

--- a/tdesign-component/lib/src/components/dialog/td_alert_dialog.dart
+++ b/tdesign-component/lib/src/components/dialog/td_alert_dialog.dart
@@ -35,6 +35,8 @@ class TDAlertDialog extends StatelessWidget {
     this.rightBtnAction,
     this.showCloseButton,
     TDDialogButtonStyle buttonStyle = TDDialogButtonStyle.normal,
+    this.padding = const EdgeInsets.fromLTRB(24, 32, 24, 0),
+    this.buttonWidget,
   })  : assert((title != null || content != null)),
         _vertical = false,
         _buttons = null,
@@ -57,6 +59,8 @@ class TDAlertDialog extends StatelessWidget {
     this.contentColor,
     this.contentMaxHeight = 0,
     this.showCloseButton,
+    this.padding = const EdgeInsets.fromLTRB(24, 32, 24, 0),
+    this.buttonWidget,
   })  : _vertical = true,
         leftBtn = null,
         rightBtn = null,
@@ -121,6 +125,12 @@ class TDAlertDialog extends StatelessWidget {
   /// [leftBtn]和[rightBtn]中的style会覆盖此配置
   final TDDialogButtonStyle _buttonStyle;
 
+  /// 内容内边距
+  final EdgeInsets? padding;
+
+  /// 自定义按钮
+  final Widget? buttonWidget;
+
   @override
   Widget build(BuildContext context) {
     // 标题和内容不能同时为空
@@ -137,6 +147,7 @@ class TDAlertDialog extends StatelessWidget {
             content: content,
             contentColor: contentColor,
             contentMaxHeight: contentMaxHeight,
+            padding: padding,
           ),
           const TDDivider(height: 24, color: Colors.transparent),
           _vertical ? _verticalButtons(context) : _horizontalButtons(context),
@@ -144,6 +155,9 @@ class TDAlertDialog extends StatelessWidget {
   }
 
   Widget _horizontalButtons(BuildContext context) {
+    if(buttonWidget != null) {
+      return buttonWidget!;
+    }
     final left = leftBtn ??
         TDDialogButtonOptions(
             title: context.resource.cancel, theme: TDButtonTheme.light, action: leftBtnAction);

--- a/tdesign-component/lib/src/components/dialog/td_confirm_dialog.dart
+++ b/tdesign-component/lib/src/components/dialog/td_confirm_dialog.dart
@@ -30,6 +30,8 @@ class TDConfirmDialog extends StatelessWidget {
     this.buttonTextColor,
     this.buttonStyle = TDDialogButtonStyle.normal,
     this.showCloseButton,
+    this.padding = const EdgeInsets.fromLTRB(24, 32, 24, 0),
+    this.buttonWidget,
   }) : super(key: key);
 
   /// 标题
@@ -74,7 +76,16 @@ class TDConfirmDialog extends StatelessWidget {
   /// 右上角关闭按钮
   final bool? showCloseButton;
 
+  /// 内容内边距
+  final EdgeInsets? padding;
+
+  /// 自定义按钮
+  final Widget? buttonWidget;
+
   Widget _buildButton(BuildContext context) {
+    if(buttonWidget != null) {
+      return buttonWidget!;
+    }
     if (buttonStyle == TDDialogButtonStyle.text) {
       return Column(
         mainAxisSize: MainAxisSize.min,
@@ -133,6 +144,7 @@ class TDConfirmDialog extends StatelessWidget {
             content: content,
             contentColor: contentColor,
             contentMaxHeight: contentMaxHeight,
+            padding: padding,
           ),
           _buildButton(context),
         ]));

--- a/tdesign-component/lib/src/components/dialog/td_dialog_widget.dart
+++ b/tdesign-component/lib/src/components/dialog/td_dialog_widget.dart
@@ -164,7 +164,7 @@ class TDDialogInfoWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // 标题和内容不能同时为空
-    assert((title != null || content != null));
+    assert((title != null || content != null || contentWidget != null));
     return Container(
       padding: padding,
       child: Column(

--- a/tdesign-component/lib/src/components/dialog/td_image_dialog.dart
+++ b/tdesign-component/lib/src/components/dialog/td_image_dialog.dart
@@ -32,6 +32,8 @@ class TDImageDialog extends StatelessWidget {
     this.leftBtn,
     this.rightBtn,
     this.showCloseButton,
+    this.padding,
+    this.buttonWidget,
   }) : super(key: key);
 
   /// 背景颜色
@@ -73,6 +75,12 @@ class TDImageDialog extends StatelessWidget {
   /// 显示右上角关闭按钮
   final bool? showCloseButton;
 
+  /// 内容内边距
+  final EdgeInsets? padding;
+
+  /// 自定义按钮
+  final Widget? buttonWidget;
+
   Widget _buildImage(BuildContext context) {
     return SizedBox(
       width: 311,
@@ -94,7 +102,7 @@ class TDImageDialog extends StatelessWidget {
       ),
       TDDialogInfoWidget(
         title: title,
-        padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+        padding: padding ?? const EdgeInsets.fromLTRB(24, 24, 24, 0),
         titleColor: titleColor,
         titleAlignment: titleAlignment,
         contentWidget: contentWidget,
@@ -109,7 +117,7 @@ class TDImageDialog extends StatelessWidget {
   Widget _buildMiddleImage(BuildContext context) {
     return Column(mainAxisSize: MainAxisSize.min, children: [
       TDDialogInfoWidget(
-        padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+        padding: padding ?? const EdgeInsets.fromLTRB(24, 24, 24, 0),
         title: title,
         titleColor: titleColor,
         titleAlignment: titleAlignment,
@@ -161,6 +169,9 @@ class TDImageDialog extends StatelessWidget {
   }
 
   Widget _horizontalButtons(BuildContext context) {
+    if (buttonWidget != null) {
+      return buttonWidget!;
+    }
     final left = leftBtn ??
         TDDialogButtonOptions(
             title: context.resource.cancel, theme: TDButtonTheme.light, action: null);

--- a/tdesign-component/lib/src/components/dialog/td_input_dialog.dart
+++ b/tdesign-component/lib/src/components/dialog/td_input_dialog.dart
@@ -27,6 +27,8 @@ class TDInputDialog extends StatelessWidget {
     this.leftBtn,
     this.rightBtn,
     this.showCloseButton,
+    this.padding = const EdgeInsets.fromLTRB(24, 32, 24, 0),
+    this.buttonWidget,
   })  : assert((title != null || content != null)),
         super(key: key);
 
@@ -69,6 +71,12 @@ class TDInputDialog extends StatelessWidget {
   /// 显示右上角关闭按钮
   final bool? showCloseButton;
 
+  /// 内容内边距
+  final EdgeInsets? padding;
+
+  /// 自定义按钮
+  final Widget? buttonWidget;
+
   @override
   Widget build(BuildContext context) {
     return TDDialogScaffold(
@@ -87,6 +95,7 @@ class TDInputDialog extends StatelessWidget {
             contentWidget: contentWidget,
             content: content,
             contentColor: contentColor,
+            padding: padding,
           ),
           Container(
             height: 48,
@@ -118,6 +127,9 @@ class TDInputDialog extends StatelessWidget {
   }
 
   Widget _horizontalButtons(BuildContext context) {
+    if(buttonWidget != null) {
+      return buttonWidget!;
+    }
     final left = leftBtn ??
         TDDialogButtonOptions(title: context.resource.cancel, titleColor: const Color(0xE6000000), fontWeight: FontWeight.normal, action: null, height: 56);
     final right = rightBtn ??


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[ #288 ](https://github.com/Tencent/tdesign-flutter/issues/288)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Dialog): 支持自定义内容内边距和按钮

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
