### PR TITLE
修复在 Flutter 3.27.0 稳定分支上的编译错误 bug

### DIFF
--- a/tdesign-component/lib/src/components/collapse/td_collapse_salted_key.dart
+++ b/tdesign-component/lib/src/components/collapse/td_collapse_salted_key.dart
@@ -17,7 +17,7 @@ class TDCollapseSaltedKey<S, V> extends LocalKey {
   }
 
   @override
-  int get hashCode => hashValues(runtimeType, salt, value);
+  int get hashCode => Object.hash(runtimeType, salt, value);
 
   @override
   String toString() {

--- a/tdesign-component/pubspec.yaml
+++ b/tdesign-component/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter_easyrefresh: ^2.2.1
 
   # 滑动单元格组件
-  flutter_slidable: 3.1.0
+  flutter_slidable: 3.1.2
 
 #  # 相册选择组件
 #  image_picker: 1.1.2


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#400
letsar/flutter_slidable#488

### 💡 需求背景和解决方案
使用 Object.hash() 代替被废弃移除的 hashValues().
升级依赖项 flutter_slidable 至版本 v3.1.2，此版本解决了同样的问题。

### 📝 更新日志
- fix(td_collapse): 修复编译错误。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
