### PR TITLE
[TDBottomTabBar] 修复iconText模式，底部溢出2.5像素

### DIFF
--- a/tdesign-component/example/lib/page/td_bottom_tab_bar_page.dart
+++ b/tdesign-component/example/lib/page/td_bottom_tab_bar_page.dart
@@ -195,6 +195,12 @@ class _TDBottomTabBarPageState extends State<TDBottomTabBarPage> {
             builder: (context) {
               return CodeWrapper(builder: _setCurrentIndexToTabBar);
             }),
+        ExampleItem(
+            ignoreCode: true,
+            desc: 'icon默认大小底部文字不溢出',
+            builder: (context) {
+              return CodeWrapper(builder: _iconTextTypeTabBarOverflow);
+            })
       ],
     );
   }
@@ -438,6 +444,44 @@ class _TDBottomTabBarPageState extends State<TDBottomTabBarPage> {
         unselectedIcon: _unSelectedIcon,
         onTap: () {
           onTapTab(context, '标签2');
+        },
+      ),
+    ]);
+  }
+
+  @Demo(group: 'bottomTabBar')
+  Widget _iconTextTypeTabBarOverflow(BuildContext context) {
+    final selectedIcon = Icon(
+      TDIcons.app,
+      color: TDTheme.of(context).brandNormalColor,
+    );
+    final unSelectedIcon = Icon(
+      TDIcons.app,
+      color: TDTheme.of(context).brandNormalColor,
+    );
+    return TDBottomTabBar(TDBottomTabBarBasicType.iconText, useVerticalDivider: false, navigationTabs: [
+      TDBottomTabBarTabConfig(
+        tabText: '标签',
+        selectedIcon: selectedIcon,
+        unselectedIcon: unSelectedIcon,
+        onTap: () {
+          onTapTab(context, '标签1');
+        },
+      ),
+      TDBottomTabBarTabConfig(
+        tabText: '标签',
+        selectedIcon: selectedIcon,
+        unselectedIcon: unSelectedIcon,
+        onTap: () {
+          onTapTab(context, '标签2');
+        },
+      ),
+      TDBottomTabBarTabConfig(
+        tabText: '标签',
+        selectedIcon: selectedIcon,
+        unselectedIcon: unSelectedIcon,
+        onTap: () {
+          onTapTab(context, '标签3');
         },
       ),
     ]);

--- a/tdesign-component/lib/src/components/tabbar/td_bottom_tab_bar.dart
+++ b/tdesign-component/lib/src/components/tabbar/td_bottom_tab_bar.dart
@@ -301,7 +301,7 @@ class _TDBottomTabBarState extends State<TDBottomTabBar> {
         height: widget.barHeight ?? _kDefaultTabBarHeight,
         width: itemWidth,
         alignment: Alignment.center,
-        padding: const EdgeInsets.symmetric(vertical: 7),
+        padding: EdgeInsets.only(top: 7, bottom: widget.basicType == TDBottomTabBarBasicType.iconText ? 5 : 7),
         child: TDBottomTabBarItemWithBadge(
           basiceType: widget.basicType,
           componentType: widget.componentType ?? TDBottomTabBarComponentType.label,
@@ -442,7 +442,7 @@ class TDBottomTabBarItemWithBadge extends StatelessWidget {
                         borderRadius: const BorderRadius.all(Radius.circular(24))),
                   )),
             Container(
-                padding: EdgeInsets.only(top: isInOrOutCapsule ? 3.0 : 2.0, bottom: isInOrOutCapsule ? 1.0 : 0.0),
+                padding: EdgeInsets.only(top: isInOrOutCapsule ? 3.0 : 2.0, bottom: isInOrOutCapsule ? (basiceType == TDBottomTabBarBasicType.iconText ? 0.0 : 1.0) : 0.0),
                 child: _constructItem(context, badgeConfig, isInOrOutCapsule)),
 
             /// )


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#353
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
![509D52F4-6F4D-4DAF-8473-F3E29C6C201B](https://github.com/user-attachments/assets/e81e0f52-20d4-4ec8-b8f2-e89c1857581f)

溢出原因是底部文本TDText组件默认带有边距，所以针对`TDBottomTabBarBasicType.iconText`类型调整了组件底边距修复该问题

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
