### PR TITLE
fix 3.22鸿蒙版本text 组件不居中问题

### DIFF
--- a/tdesign-component/lib/src/components/text/td_text.dart
+++ b/tdesign-component/lib/src/components/text/td_text.dart
@@ -435,7 +435,9 @@ class TDTextPaddingConfig {
           ? 29 / 128
           : PlatformUtil.isAndroid
               ? -20 / 128
-              : -10 / 128;
+              : PlatformUtil.isOhos
+                ? 43 / 128
+                : -10 / 128;
     }
     return PlatformUtil.isWeb
         ? 3 / 8


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue


### 💡 需求背景和解决方案

![image](https://github.com/user-attachments/assets/8cab4310-6ef8-449c-8a8b-39d589f191d5)
text 组件 鸿蒙3.22版本居中
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
