### PR TITLE
Fix/td alert dialog btn height

### DIFF
--- a/tdesign-component/lib/src/components/dialog/td_dialog_widget.dart
+++ b/tdesign-component/lib/src/components/dialog/td_dialog_widget.dart
@@ -307,7 +307,8 @@ class HorizontalTextButtons extends StatelessWidget {
                 buttonStyle: leftBtn.style,
                 buttonType: leftBtn.type ?? TDButtonType.text,
                 buttonTheme: leftBtn.theme,
-                height: leftBtn.height,
+                // fix： The button height does not fill the container.
+                height: 56,
                 buttonTextFontWeight: leftBtn.fontWeight,
                 onPressed: () {
                   if(leftBtn.action != null){
@@ -330,7 +331,7 @@ class HorizontalTextButtons extends StatelessWidget {
                 buttonStyle: leftBtn.style,
                 buttonType: leftBtn.type ?? TDButtonType.text,
                 buttonTheme: leftBtn.theme ?? TDButtonTheme.primary,
-                height: rightBtn.height,
+                height: 56,
                 buttonTextFontWeight: rightBtn.fontWeight ?? FontWeight.w600,
                 onPressed: () {
                   if(rightBtn.action != null){


### PR DESCRIPTION
https://github.com/Tencent/tdesign-flutter/issues/425

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-flutter/issues/425

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
问题：未指定按钮高度，导致[TDAlertDialog] 按钮样式没有铺满
解决：设置按钮高度跟分割线一致
截图：
<img width="358" alt="Clipboard_Screenshot_1737362870" src="https://github.com/user-attachments/assets/a335e916-2f4b-47be-8a93-f8fa41fe8c8a" />


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...
- 
[TDAlertDialog] 按钮样式没有铺满

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
