### PR TITLE
[Button]添加图标位置属性，可调整图标在文字右侧

### DIFF
--- a/tdesign-component/example/lib/page/td_button_page.dart
+++ b/tdesign-component/example/lib/page/td_button_page.dart
@@ -396,6 +396,12 @@ class _TDButtonPageState extends State<TDButtonPage> {
                     },
                   );
                 }),
+            ExampleItem(
+                ignoreCode: true,
+                desc: '图标在文字右侧',
+                builder: (context) {
+                  return CodeWrapper(builder: _buildRightIconButton);
+                }),
           ],
         ));
   }
@@ -794,6 +800,46 @@ class _TDButtonPageState extends State<TDButtonPage> {
         height: 24,
         width: 24,
         color: Colors.red,
+      ),
+    );
+  }
+
+  @Demo(group: 'button')
+  Widget _buildRightIconButton(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.all(16),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: [
+          TDButton(
+            text: '填充按钮',
+            icon: TDIcons.app,
+            size: TDButtonSize.large,
+            type: TDButtonType.fill,
+            shape: TDButtonShape.rectangle,
+            theme: TDButtonTheme.primary,
+            iconPosition: TDButtonIconPosition.right,
+          ),
+          TDButton(
+            icon: TDIcons.app,
+            size: TDButtonSize.large,
+            type: TDButtonType.fill,
+            shape: TDButtonShape.rectangle,
+            theme: TDButtonTheme.primary,
+            iconPosition: TDButtonIconPosition.right,
+          ),
+          TDButton(
+            text: '间距20',
+            icon: TDIcons.app,
+            size: TDButtonSize.large,
+            type: TDButtonType.fill,
+            shape: TDButtonShape.rectangle,
+            theme: TDButtonTheme.primary,
+            iconPosition: TDButtonIconPosition.right,
+            iconTextSpacing: 20,
+          )
+        ],
       ),
     );
   }

--- a/tdesign-component/lib/src/components/button/td_button.dart
+++ b/tdesign-component/lib/src/components/button/td_button.dart
@@ -12,6 +12,8 @@ enum TDButtonTheme { defaultTheme, primary, danger, light }
 
 enum TDButtonStatus { defaultState, active, disable }
 
+enum TDButtonIconPosition { left, right }
+
 typedef TDButtonEvent = void Function();
 
 /// TD常规按钮
@@ -39,7 +41,8 @@ class TDButton extends StatefulWidget {
       this.iconTextSpacing,
       this.onLongPress,
       this.margin,
-      this.padding})
+      this.padding,
+      this.iconPosition = TDButtonIconPosition.left})
       : super(key: key);
 
   /// 自控件
@@ -98,6 +101,9 @@ class TDButton extends StatefulWidget {
 
  /// 自定义图标与文本之间距离
   final double? iconTextSpacing;
+
+  /// 图标位置
+  final TDButtonIconPosition? iconPosition;
 
   /// 自定义padding
   final EdgeInsetsGeometry? padding;
@@ -226,7 +232,7 @@ class _TDButtonState extends State<TDButton> {
     }
     var children = <Widget>[];
     // 系统Icon会导致不居中，因此自绘icon指定height
-    if (icon != null) {
+    if (icon != null && widget.iconPosition == TDButtonIconPosition.left) {
       children.add(icon);
     }
     if (widget.text != null) {
@@ -238,6 +244,9 @@ class _TDButtonState extends State<TDButton> {
         forceVerticalCenter: true,
       );
       children.add(text);
+    }
+    if (icon != null && widget.iconPosition == TDButtonIconPosition.right) {
+      children.add(icon);
     }
 
     if (children.length == 2) {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
#414 
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

新增`iconPosition`参数用于调整图标位置，参数为枚举值`left`和`right`，默认`left`

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(button): 添加按钮图标位置属性

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
