### PR TITLE
Feat(upload): Add onMaxLimitReached function

### DIFF
--- a/tdesign-component/example/assets/api/upload_api.md
+++ b/tdesign-component/example/assets/api/upload_api.md
@@ -11,7 +11,12 @@
 | onCancel | VoidCallback? | - | 监听取消上传 |
 | onError | TDUploadErrorEvent? | - | 监听获取资源错误 |
 | onValidate | TDUploadValidatorEvent? | - | 监听文件校验出错 |
+| onMaxLimitReached | VoidCallback? | - | 监听文件数量超过最大限制回调函数 |
 | onClick | TDUploadClickEvent? | - | 监听点击图片位 |
 | files | List<TDUploadFile> | - | 控制展示的文件列表 |
 | onChange | TDUploadValueChangedEvent? | - | 监听添加或删除照片 |
 | multiple | bool | false | 是否多选上传，默认false |
+| width | double? | - | 图片宽度 |
+| height | double? | - | 图片高度 |
+| type | TDUploadBoxType? | - | Box类型 |
+| enabledReplaceType | bool? | false | 是否启用replace功能 |

--- a/tdesign-site/src/upload/README.md
+++ b/tdesign-site/src/upload/README.md
@@ -143,6 +143,7 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | onCancel | VoidCallback? | - | 监听取消上传 |
 | onError | TDUploadErrorEvent? | - | 监听获取资源错误 |
 | onValidate | TDUploadValidatorEvent? | - | 监听文件校验出错 |
+| onMaxLimitReached | VoidCallback? | - | 监听文件数量超过最大限制回调函数 |
 | onClick | TDUploadClickEvent? | - | 监听点击图片位 |
 | files | List<TDUploadFile> | - | 控制展示的文件列表 |
 | onChange | TDUploadValueChangedEvent? | - | 监听添加或删除照片 |


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [x] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

CC #440

### 💡 需求背景和解决方案

1. 新增`onMaxLimitReached`回调函数，该回调函数可以自定义处理文件数量超过最大限制的情况，例如显示提示信息
例如：
```dart
onMaxLimitReached: () {
    TDToast.showText('选择的图片数量超过最大限制', context: context);
},
```
2. 更新API文档说明

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
