### PR TITLE
`TDInput`: 修复非中文标签Input框宽度计算缺陷

### DIFF
--- a/tdesign-component/example/assets/code/calendar._buildSimple.txt
+++ b/tdesign-component/example/assets/code/calendar._buildSimple.txt
@@ -259,7 +259,7 @@ Widget _buildSimple(BuildContext context) {
                         dateStartTime.minute,
                         dateStartTime.second
                       ],
-                      dateEnd: [2099, 12, 30, 24, 59, 59],
+                      dateEnd: [2099, 12, 30, 23, 59, 59],
                       dateInitial:[dateEndTime.year, dateEndTime.month, dateEndTime.day, dateEndTime.hour, dateEndTime.minute, dateEndTime.second],
                     )
                   ],

--- a/tdesign-component/example/assets/code/input._basicTypeBasic.txt
+++ b/tdesign-component/example/assets/code/input._basicTypeBasic.txt
@@ -3,10 +3,10 @@
     return Column(
       children: [
         TDInput(
-          leftLabel: '标签文字',
+          leftLabel: 'Label Text',
           controller: controller[0],
           backgroundColor: Colors.white,
-          hintText: '请输入文字',
+          hintText: 'Please enter text',
           onChanged: (text) {
             setState(() {});
           },

--- a/tdesign-component/example/lib/page/td_input_page.dart
+++ b/tdesign-component/example/lib/page/td_input_page.dart
@@ -115,10 +115,10 @@ class _TDInputViewPageState extends State<TDInputViewPage> {
     return Column(
       children: [
         TDInput(
-          leftLabel: '标签文字',
+          leftLabel: 'Label Text',
           controller: controller[0],
           backgroundColor: Colors.white,
-          hintText: '请输入文字',
+          hintText: 'Please enter text',
           onChanged: (text) {
             setState(() {});
           },


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？
> 勾选规则:
> 1.只要有新增参数，就勾选”新特性提交“
> 2.只修改内部bug，未新增参数，才勾选”日常 bug 修复“
> 3.其他选项视具体改动判断

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

CC #549 and #454

### 💡 需求背景和解决方案

1. 移除原先初始化计算左侧内容宽度，太过复杂。
2. 重新新增 输入框左侧信息总宽度函数 和 文本渲染宽度 函数
3. 删除文本超长 `overflow: TextOverflow.ellipsis` .
4. 移除`onTap`函数

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] pr目标分支为develop分支，请勿直接往main分支合并
- [x] 标题格式为：`组件类名`: 修改描述（示例：`TDBottomTabBar`: 修复iconText模式，底部溢出2.5像素）
- [x] ”相关issue“处带上修复的issue链接
- [ ] 相关文档已补充或无须补充
