### PR TITLE
DropdownMenu: 修复特定情况下多列单选组件失效

### DIFF
--- a/tdesign-component/lib/src/components/dropdown_menu/td_dropdown_item.dart
+++ b/tdesign-component/lib/src/components/dropdown_menu/td_dropdown_item.dart
@@ -343,8 +343,8 @@ class _TDDropdownItemState extends State<TDDropdownItem> {
 
   void _handleSelectChange(selected) {
     var isRadio = widget.multiple != true && selected is List<String>;
-    if (isRadio) {
-      selected.removeAt(0);
+    if (isRadio && selected.isNotEmpty) {
+      selected = [selected.last];
     }
     widget.options?.forEach((element) {
       element.selected = selected is List<String> ? selected.contains(element.value) : element.value == selected;

--- a/tdesign-component/lib/src/components/dropdown_menu/td_dropdown_item.dart
+++ b/tdesign-component/lib/src/components/dropdown_menu/td_dropdown_item.dart
@@ -345,6 +345,7 @@ class _TDDropdownItemState extends State<TDDropdownItem> {
     var isRadio = widget.multiple != true && selected is List<String>;
     if (isRadio && selected.isNotEmpty) {
       selected = [selected.last];
+      print("selected: $selected");
     }
     widget.options?.forEach((element) {
       element.selected = selected is List<String> ? selected.contains(element.value) : element.value == selected;
@@ -353,7 +354,7 @@ class _TDDropdownItemState extends State<TDDropdownItem> {
       setState(() {});
     }
     widget.onChange?.call(_getSelected(widget.options).map((e) => e!.value).toList());
-    if (widget.multiple != true) {
+    if (widget.multiple != true && selected.isNotEmpty) {
       _handleClose();
     }
   }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？
> 勾选规则:
> 1.只要有新增参数，就勾选”新特性提交“
> 2.只修改内部bug，未新增参数，才勾选”日常 bug 修复“
> 3.其他选项视具体改动判断

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue


https://github.com/Tencent/tdesign-flutter/issues/552



### 💡 需求背景和解决方案


1. 解决多列单选，如果取消选中，再点击另一个，会导致组件彻底失效bug


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] pr目标分支为develop分支，请勿直接往main分支合并
- [x] 标题格式为：`组件类名`: 修改描述（示例：`TDBottomTabBar`: 修复iconText模式，底部溢出2.5像素）
- [x] ”相关issue“处带上修复的issue链接
- [x] 相关文档已补充或无须补充
