### PR TITLE
TDPopup``: 修复无法通过child中的height来修改弹出层高度

### DIFF
--- a/tdesign-component/example/lib/page/td_popup_page.dart
+++ b/tdesign-component/example/lib/page/td_popup_page.dart
@@ -464,7 +464,7 @@ class TDPopupPageState extends State<TDPopupPage> {
                           Navigator.maybePop(context);
                         },
                         child: Container(
-                          height: 200,
+                          height: 20,
                         ),
                       );
                     }));
@@ -495,7 +495,7 @@ class TDPopupPageState extends State<TDPopupPage> {
                                     Navigator.maybePop(context);
                                   },
                                   child: Container(
-                                    height: 200,
+                                    height: 20,
                                   ),
                                 );
                               }));


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？
> 勾选规则:
> 1.只要有新增参数，就勾选”新特性提交“
> 2.只修改内部bug，未新增参数，才勾选”日常 bug 修复“
> 3.其他选项视具体改动判断

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

CC #551

### 💡 需求背景和解决方案

1. 新增`_measureChildHeight()`函数用于量子组件高度并更新弹窗布局参数
2. 修改`Expanded`为`SizeBox`

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] pr目标分支为develop分支，请勿直接往main分支合并
- [ ] 标题格式为：`组件类名`: 修改描述（示例：`TDBottomTabBar`: 修复iconText模式，底部溢出2.5像素）
- [ ] ”相关issue“处带上修复的issue链接
- [ ] 相关文档已补充或无须补充
