### PR TITLE
`TDPopup`: 为Popup组件添加标题、左文本、右文本和关闭按钮自定义尺寸属性

### DIFF
--- a/tdesign-component/lib/src/components/popup/td_popup_panel.dart
+++ b/tdesign-component/lib/src/components/popup/td_popup_panel.dart
@@ -232,9 +232,11 @@ class TDPopupBottomDisplayPanel extends TDPopupBasePanel {
     required super.child,
     super.title,
     super.titleColor,
+    this.titleFontSize,
     this.titleLeft = false,
     this.hideClose = false,
     this.closeColor,
+    this.closeSize,
     this.closeClick,
     super.backgroundColor,
     super.radius,
@@ -242,13 +244,16 @@ class TDPopupBottomDisplayPanel extends TDPopupBasePanel {
     super.maxHeightRatio,
     super.minHeightRatio,
   });
-
+  /// 标题字体大小
+  final double? titleFontSize;
   /// 标题是否靠左
   final bool titleLeft;
   /// 是否隐藏关闭按钮
   final bool hideClose;
   /// 关闭按钮颜色
   final Color? closeColor;
+  /// 关闭按钮图标尺寸
+  final double? closeSize;
   /// 关闭按钮点击回调
   final PopupClick? closeClick;
 
@@ -265,7 +270,10 @@ class _TDPopupBottomDisplayPanelState extends _TDPopupBaseState<TDPopupBottomDis
       child: TDText(
         widget.title ?? '',
         textColor: widget.titleColor ?? TDTheme.of(context).fontGyColor1,
-        font: TDTheme.of(context).fontTitleLarge,
+        font: TDTheme.of(context).fontTitleLarge?.withSize(
+            widget.titleFontSize?.toInt() ??
+                TDTheme.of(context).fontTitleLarge!.size.toInt()
+        ),
         fontWeight: FontWeight.w700,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
@@ -288,7 +296,7 @@ class _TDPopupBottomDisplayPanelState extends _TDPopupBaseState<TDPopupBottomDis
             child: IconButton(
               icon: Icon(TDIcons.close,
                 color: widget.closeColor,
-                size: 24,
+                size: widget.closeSize,
               ),
               onPressed: widget.closeClick,
             ),
@@ -334,21 +342,29 @@ class TDPopupBottomConfirmPanel extends TDPopupBasePanel {
     this.rightText,
     this.rightTextColor,
     this.rightClick,
+    this.titleFontSize,
+    this.leftTextFontSize,
+    this.rightTextFontSize,
     super.backgroundColor,
     super.radius,
     super.draggable,
     super.maxHeightRatio,
     super.minHeightRatio,
   });
-
+  /// 标题字体大小
+  final double? titleFontSize;
   /// 左边文本
   final String? leftText;
+  /// 左边文本字体大小
+  final double? leftTextFontSize;
   /// 左边文本颜色
   final Color? leftTextColor;
   /// 左边文本点击回调
   final PopupClick? leftClick;
   /// 右边文本
   final String? rightText;
+  /// 右边文本字体大小
+  final double? rightTextFontSize;
   /// 右边文本颜色
   final Color? rightTextColor;
   /// 右边文本点击回调
@@ -379,7 +395,10 @@ class _TDPopupBottomConfirmPanelState extends _TDPopupBaseState<TDPopupBottomCon
               child: TDText(
                 widget.title ?? '',
                 textColor: widget.titleColor ?? TDTheme.of(context).fontGyColor1,
-                font: TDTheme.of(context).fontTitleLarge,
+                font: TDTheme.of(context).fontTitleLarge?.withSize(
+                    widget.titleFontSize?.toInt() ??
+                        TDTheme.of(context).fontTitleLarge!.size.toInt()
+                ),
                 fontWeight: FontWeight.w700,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
@@ -412,9 +431,14 @@ class _TDPopupBottomConfirmPanelState extends _TDPopupBaseState<TDPopupBottomCon
       child: TDText(
         text,
         textColor: color,
-        font: left
+        font: (left
             ? TDTheme.of(context).fontBodyLarge
-            : TDTheme.of(context).fontTitleMedium,
+            : TDTheme.of(context).fontTitleMedium
+        )?.withSize(
+            left
+                ? widget.leftTextFontSize?.toInt() ?? TDTheme.of(context).fontBodyLarge!.size.toInt()
+                : widget.rightTextFontSize?.toInt() ?? TDTheme.of(context).fontTitleMedium!.size.toInt()
+        ),
         fontWeight: left ? FontWeight.w400 : FontWeight.w600,
       ),
     ),
@@ -447,6 +471,7 @@ class TDPopupCenterPanel extends StatelessWidget {
     this.closeClick,
     this.backgroundColor,
     this.radius,
+    this.closeSize,
   });
 
   /// 子控件
@@ -455,6 +480,8 @@ class TDPopupCenterPanel extends StatelessWidget {
   final bool closeUnderBottom;
   /// 关闭按钮颜色
   final Color? closeColor;
+  /// 关闭按钮图标尺寸
+  final double? closeSize;
   /// 关闭按钮点击回调
   final PopupClick? closeClick;
   /// 背景颜色
@@ -480,7 +507,7 @@ class TDPopupCenterPanel extends StatelessWidget {
           IconButton(
             icon: Icon(TDIcons.close_circle,
               color: closeColor ?? TDTheme.of(context).fontWhColor1,
-              size: 40,
+              size: closeSize,
             ),
             onPressed: closeClick,
           ),
@@ -502,7 +529,7 @@ class TDPopupCenterPanel extends StatelessWidget {
             child: IconButton(
               icon: Icon(TDIcons.close,
                 color: closeColor,
-                size: 24,
+                size: closeSize,
               ),
               onPressed: closeClick,
             ),

--- a/tdesign-component/lib/src/theme/basic.dart
+++ b/tdesign-component/lib/src/theme/basic.dart
@@ -30,3 +30,12 @@ class FontFamily {
   factory FontFamily.fromJson(Map<String, dynamic> map) =>
       FontFamily(fontFamily: map['fontFamily'], package: map['package']);
 }
+
+/// Font字体宽高的扩展
+extension FontExtensions on Font {
+  Font withSize(int newSize) => Font(
+      size: newSize,
+      lineHeight: (height * newSize).round(),
+      fontWeight: fontWeight
+  );
+}


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？
> 勾选规则:
> 1.只要有新增参数，就勾选”新特性提交“
> 2.只修改内部bug，未新增参数，才勾选”日常 bug 修复“
> 3.其他选项视具体改动判断

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

CC #523

### 💡 需求背景和解决方案

1. TDPopupBottomDisplayPanel：
添加了 标题字体大小（titleFontSize），关闭按钮图标尺寸（closeSize）

2. TDPopupBottomConfirmPanel：
添加了 标题字体大小（titleFontSize），左边文本字体大小（leftTextFontSize），右边文本字体大小（rightTextFontSize）

3. TDPopupCenterPanel:
添加了 关闭按钮图标尺寸（closeSize）

参数都是可空类型，当为空，取系统默认字体大小。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] pr目标分支为develop分支，请勿直接往main分支合并
- [x] 标题格式为：`组件类名`: 修改描述（示例：`TDBottomTabBar`: 修复iconText模式，底部溢出2.5像素）
- [x] ”相关issue“处带上修复的issue链接
- [ ] 相关文档已补充或无须补充
