### PR TITLE
`TDPicker`: 支持切换时优先保持级联的选项值

### DIFF
--- a/tdesign-component/example/lib/page/td_picker_page.dart
+++ b/tdesign-component/example/lib/page/td_picker_page.dart
@@ -25,8 +25,12 @@ class _TDPickerPageState extends State<TDPickerPage> {
       '佛山市': [''],
       '广州市广州市广州市广州市广州市广州市广州市广州市广州市广州市广州市': ['花都区']
     },
+    '广东省2': {
+      '深圳市': ['南山区南山区南山区南山区南山区', '罗湖区', '福田区'],
+      '广州市广州市广州市广州市广州市广州市广州市广州市广州市广州市广州市': ['花都区']
+    },
     '重庆市': {
-      '重庆市重庆市重庆市重庆市重庆市重庆市重庆市': ['九龙坡区', '江北区']
+      '重庆市重庆市重庆市重庆市重庆市重庆市重庆市': ['九龙坡区', '江北区'],
     },
     '浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省': {
       '杭州市': ['西湖区', '余杭区', '萧山区'],
@@ -34,7 +38,7 @@ class _TDPickerPageState extends State<TDPickerPage> {
     },
     '香港': {
       '香港': ['九龙城区', '黄大仙区', '离岛区', '湾仔区']
-    }
+    },
   };
 
   String selected_5 = '';
@@ -76,6 +80,8 @@ class _TDPickerPageState extends State<TDPickerPage> {
       test: [
         ExampleItem(
             desc: '自定义left/right text', builder: buildCustomLeftRightText),
+        ExampleItem(
+            desc: '级联选择保持下一级选项', builder: buildKeepMultiArea),
       ],
     );
   }
@@ -196,6 +202,26 @@ class _TDPickerPageState extends State<TDPickerPage> {
           child: buildSelectRow(context, selected_3, '联动选择器'),
         )
       ],
+    );
+  }
+
+  @Demo(group: 'picker')
+  Widget buildKeepMultiArea(BuildContext context) {
+    return GestureDetector(
+      onTap: (){
+        TDPicker.showMultiLinkedPicker(context, title: '选择地区',
+            onConfirm: (selected) {
+              setState(() {
+                selected_3 = '${selected[0]} ${selected[1]} ${selected[2]}';
+              });
+              Navigator.of(context).pop();
+            },
+            data: data_3,
+            columnNum: 3,
+            keepSameSelection: true,
+            initialData: ['广东省', '深圳市', '罗湖区']);
+      },
+      child: buildSelectRow(context, selected_3, '选择地区'),
     );
   }
 

--- a/tdesign-component/lib/src/components/picker/td_multi_picker.dart
+++ b/tdesign-component/lib/src/components/picker/td_multi_picker.dart
@@ -391,6 +391,9 @@ class TDMultiLinkedPicker extends StatefulWidget {
   /// 自定义item构建
   final ItemBuilderType? itemBuilder;
 
+  /// 是否保留相同选项
+  final bool keepSameSelection;
+
   const TDMultiLinkedPicker({
     this.title,
     required this.onConfirm,
@@ -416,6 +419,7 @@ class TDMultiLinkedPicker extends StatefulWidget {
     this.padding,
     this.itemDistanceCalculator,
     this.itemBuilder,
+    this.keepSameSelection = false,
     Key? key,
   }) : super(key: key);
 
@@ -435,7 +439,7 @@ class _TDMultiLinkedPickerState extends State<TDMultiLinkedPicker> {
     super.initState();
     pickerHeight = widget.pickerHeight;
     model = MultiLinkedPickerModel(
-        data: widget.data, columnNum: widget.columnNum, initialData: widget.selectedData);
+        data: widget.data, columnNum: widget.columnNum, initialData: widget.selectedData, keepSameSelection: widget.keepSameSelection);
   }
 
   @override
@@ -671,10 +675,14 @@ class MultiLinkedPickerModel {
   /// 每一列展示的数据
   late List<List> presentData = [];
 
+  /// 是否保留相同选项
+  bool keepSameSelection = false;
+
   MultiLinkedPickerModel({
     required this.data,
     required this.columnNum,
     required List initialData,
+    this.keepSameSelection = false,
   }) {
     selectedData = [];
     selectedIndexes = [];
@@ -773,6 +781,22 @@ class MultiLinkedPickerModel {
       } else {
         presentData[position + 1] = findColumnData(position + 1);
       }
+
+      // 新增保留相同选项逻辑
+      if (keepSameSelection && position + 1 < selectedData.length) {
+        var nextPosition = position + 1;
+        var oldSelected = selectedData[nextPosition];
+        var newDataList = presentData[nextPosition];
+
+        // 查找旧值是否存在于新数据列表中
+        var index = newDataList.indexOf(oldSelected);
+        if (index != -1) {
+          // 存在相同值则保留原选择
+          refreshPresentDataAndController(nextPosition, index, true);
+          return;
+        }
+      }
+
       refreshPresentDataAndController(position + 1, 0, true);
     }
   }

--- a/tdesign-component/lib/src/components/picker/td_picker.dart
+++ b/tdesign-component/lib/src/components/picker/td_picker.dart
@@ -143,6 +143,7 @@ class TDPicker {
       Color? titleDividerColor,
       Widget? customSelectWidget,
       double? topPadding,
+      bool keepSameSelection = false,
       int pickerItemCount = 5}) {
     showModalBottomSheet(
         context: context,
@@ -166,6 +167,7 @@ class TDPicker {
             titleDividerColor: titleDividerColor,
             topPadding: topPadding,
             customSelectWidget: customSelectWidget,
+            keepSameSelection: keepSameSelection,
           );
         });
   }


### PR DESCRIPTION
- 在 TDMultiLinkedPicker 和 TDPicker 中添加 keepSameSelection 参数
- 实现了在重新选择时保留相同选项的功能
- 更新了示例页面，增加了保留下一级选项的演示

### 🤔 这个 PR 的性质是？
> 勾选规则:
> 1.只要有新增参数，就勾选”新特性提交“
> 2.只修改内部bug，未新增参数，才勾选”日常 bug 修复“
> 3.其他选项视具体改动判断

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#658 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
新增`keepSameSelection`参数，默认为`false`，设置为`true`后支持切换时优先保持级联的选项值
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] pr目标分支为develop分支，请勿直接往main分支合并
- [x] 标题格式为：`组件类名`: 修改描述（示例：`TDBottomTabBar`: 修复iconText模式，底部溢出2.5像素）
- [x] ”相关issue“处带上修复的issue链接
- [x] 相关文档已补充或无须补充
