### PR TITLE
TDMultiCascader: 修复在无约束高度父组件中崩溃的问题

### DIFF
--- a/tdesign-component/lib/src/components/cascader/td_multi_cascader.dart
+++ b/tdesign-component/lib/src/components/cascader/td_multi_cascader.dart
@@ -144,6 +144,7 @@ class _TDMultiCascaderState extends State<TDMultiCascader>
 
     return Container(
       width: maxWidth,
+      height: widget.cascaderHeight,
       decoration: BoxDecoration(
         color: widget.backgroundColor ?? TDTheme.of(context).bgColorContainer,
         borderRadius: BorderRadius.only(

--- a/tdesign-component/test/td_multi_cascader_test.dart
+++ b/tdesign-component/test/td_multi_cascader_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tdesign_flutter/tdesign_flutter.dart';
+
+void main() {
+  testWidgets('TDMultiCascader works inside SingleChildScrollView', (WidgetTester tester) async {
+    final data = [
+      {
+        "value": "1",
+        "label": "Dept 1",
+        "children": [
+          {"value": "1-1", "label": "Dept 1-1"},
+        ]
+      },
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: TDMultiCascader(
+              title: 'Test',
+              cascaderHeight: 400,
+              data: data,
+              onChange: (value) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // If it renders without throwing exception, it passed.
+    expect(find.text('Test'), findsOneWidget);
+    expect(find.text('Dept 1'), findsOneWidget);
+    expect(find.byType(TDMultiCascader), findsOneWidget);
+  });
+
+  testWidgets('TDMultiCascader with initialIndexes', (WidgetTester tester) async {
+    final data = [
+      {
+        "value": "1",
+        "label": "Province 1",
+        "children": [
+          {
+            "value": "1-1",
+            "label": "City 1-1",
+            "children": [
+              {"value": "1-1-1", "label": "District 1-1-1"},
+              {"value": "1-1-2", "label": "District 1-1-2"},
+            ]
+          },
+          {"value": "1-2", "label": "City 1-2"},
+        ]
+      },
+      {"value": "2", "label": "Province 2"},
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TDMultiCascader(
+            title: 'Test with initialIndexes',
+            cascaderHeight: 400,
+            data: data,
+            initialIndexes: [0, 0, 1],
+            onChange: (value) {},
+          ),
+        ),
+      ),
+    );
+
+    // Wait for initialization
+    await tester.pumpAndSettle();
+
+    // Verify the widget renders
+    expect(find.byType(TDMultiCascader), findsOneWidget);
+    expect(find.text('Test with initialIndexes'), findsOneWidget);
+  });
+
+  testWidgets('TDMultiCascader with empty initialIndexes', (WidgetTester tester) async {
+    final data = [
+      {
+        "value": "1",
+        "label": "Item 1",
+        "children": [
+          {"value": "1-1", "label": "Item 1-1"},
+        ]
+      },
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TDMultiCascader(
+            title: 'Test empty initialIndexes',
+            cascaderHeight: 400,
+            data: data,
+            initialIndexes: [],
+            onChange: (value) {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Should still render without error
+    expect(find.byType(TDMultiCascader), findsOneWidget);
+    expect(find.text('Test empty initialIndexes'), findsOneWidget);
+  });
+
+  testWidgets('TDMultiCascader with invalid initialIndexes', (WidgetTester tester) async {
+    final data = [
+      {
+        "value": "1",
+        "label": "Item 1",
+        "children": [
+          {"value": "1-1", "label": "Item 1-1"},
+        ]
+      },
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TDMultiCascader(
+            title: 'Test invalid initialIndexes',
+            cascaderHeight: 400,
+            data: data,
+            initialIndexes: [10, 20, 30], // Invalid indexes
+            onChange: (value) {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Should still render without crashing
+    expect(find.byType(TDMultiCascader), findsOneWidget);
+    expect(find.text('Test invalid initialIndexes'), findsOneWidget);
+  });
+}

--- a/tdesign-site/src/cascader/README.md
+++ b/tdesign-site/src/cascader/README.md
@@ -234,6 +234,45 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 </td-code-block>
                                   
 
+使用索引初始化选择器
+            
+<td-code-block panel="Dart">
+
+  <pre slot="Dart" lang="javascript">
+  Widget _buildWithInitialIndexes(BuildContext context) {
+    return TDCell(
+      title: '选择地区',
+      note: _selected_1.isEmpty ? '请选择' : _selected_1,
+      arrow: true,
+      onClick: (click) {
+        TDCascader.showMultiCascader(
+          context,
+          title: '选择地址',
+          data: _data,
+          initialIndexes: [0, 0, 1],
+          theme: 'step',
+          onChange: (List<MultiCascaderListModel> selectData) {
+            setState(() {
+              var result = [];
+              var len = selectData.length;
+              _initData = selectData[len - 1].value!;
+              selectData.forEach((element) {
+                result.add(element.label);
+              });
+              _selected_1 = result.join('/');
+            });
+          },
+          onClose: () {
+            Navigator.of(context).pop();
+          },
+        );
+      },
+    );
+  }</pre>
+
+</td-code-block>
+                                  
+
 
 ## API
 ### TDMultiCascader


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#705

### 💡 需求背景和解决方案

**问题描述：**
当 TDMultiCascader 在无约束高度的父组件中使用时（例如在 TDDropdownItem 的 SingleChildScrollView 中），内部的 Expanded widget 会导致布局错误并崩溃。

**解决方案：**
在 TDMultiCascader 的根 Container 上添加 `height: widget.cascaderHeight` 属性，确保组件有固定高度，从而解决与 TDDropdownItem 等组件的兼容性问题。

**修改内容：**
1. 修复了 TDMultiCascader 在无约束高度父组件中崩溃的问题
2. 添加了完整的测试用例，包括：
   - 在 SingleChildScrollView 中使用的测试
   - initialIndexes 功能的测试（正常、空值、异常情况）
3. 在文档中添加了 initialIndexes 的使用示例

### 📝 更新日志

- fix(TDMultiCascader): 修复在无约束高度父组件中崩溃的问题
- test(TDMultiCascader): 添加测试用例和文档示例
- docs(Cascader): 添加 initialIndexes 使用示例

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] pr目标分支为develop分支，请勿直接往main分支合并
- [x] 标题格式为：`组件类名`: 修改描述
- [x] "相关issue"处带上修复的issue链接
- [x] 相关文档已补充或无须补充