### PR TITLE
fix(TDInput): password input keyboard not popping up on first tap (#763)

### DIFF
--- a/tdesign-component/example/lib/page/td_input_page.dart
+++ b/tdesign-component/example/lib/page/td_input_page.dart
@@ -86,6 +86,9 @@ class _TDInputViewPageState extends State<TDInputViewPage> {
               ExampleItem(desc: '自适应高度输入框', builder: _autoHeightInput),
               ExampleItem(builder: _specialTypeNumber),
               ExampleItem(builder: _specialTypePasswordWithPaste),
+              ExampleItem(
+                  desc: '登录场景：双密码框焦点切换不收键盘',
+                  builder: _specialTypeLoginForm),
               ExampleItem(builder: (context) {
                 return Container();
               }),
@@ -494,6 +497,42 @@ class _TDInputViewPageState extends State<TDInputViewPage> {
           height: 16,
         ),
       ],
+    );
+  }
+
+  @Demo(group: 'input')
+  Widget _specialTypeLoginForm(BuildContext context) {
+    // 登录场景：上下两个密码框，演示 issue #763 的修复效果。
+    // - 点击任一密码框：键盘应立即弹出（无需点两次）
+    // - 在两个密码框间切换焦点：键盘保持显示，不会被默认 onTapOutside 收起
+    // - 借助 AutofillGroup + AutofillHints.password 触发系统密码自动填充
+    return AutofillGroup(
+      child: Column(
+        children: [
+          TDInput(
+            type: TDInputType.normal,
+            controller: controller[28],
+            obscureText: true,
+            leftLabel: '密码',
+            hintText: '请输入密码',
+            autofillHints: const [AutofillHints.password],
+            inputAction: TextInputAction.next,
+            needClear: false,
+          ),
+          const SizedBox(height: 8),
+          TDInput(
+            type: TDInputType.normal,
+            controller: controller[29],
+            obscureText: true,
+            leftLabel: '确认密码',
+            hintText: '请再次输入密码',
+            autofillHints: const [AutofillHints.password],
+            inputAction: TextInputAction.done,
+            needClear: false,
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
     );
   }
 

--- a/tdesign-component/lib/src/components/input/input_view.dart
+++ b/tdesign-component/lib/src/components/input/input_view.dart
@@ -82,6 +82,11 @@ class TDInputView extends StatelessWidget {
   /// 是否启用交互式选择
   final bool? enableInteractiveSelection;
 
+  /// 自动填充提示，传递给 TextField 的 autofillHints
+  /// 例如密码输入框传 [AutofillHints.password]，可让系统/输入法识别为密码字段
+  /// 配合 AutofillGroup 使用可触发系统自动填充
+  final Iterable<String>? autofillHints;
+
   const TDInputView(
       {Key? key,
       required this.textStyle,
@@ -110,10 +115,26 @@ class TDInputView extends StatelessWidget {
       this.onTapOutside,
       this.selectionControls,
       this.contextMenuBuilder,
-      this.enableInteractiveSelection})
+      this.enableInteractiveSelection,
+      this.autofillHints})
       : super(
           key: key,
         );
+
+  /// 默认的 onTapOutside 实现：不主动 unfocus 当前输入框。
+  ///
+  /// Flutter 3.13+ 的 EditableText 默认 onTapOutside 会在指针落到输入框外部
+  /// 任意位置时调用 focusNode.unfocus()，导致以下交互问题（见 issue #763）：
+  /// 1. Android 上从一个 TDInput 点击切换到另一个 TDInput 时，前者的
+  ///    onTapOutside 会先 unfocus，与后者的 requestFocus 在同一帧竞争，
+  ///    最终表现为键盘被收起；
+  /// 2. 在 Stack/Row 等复杂布局中，第一次 tap 触发 outside 判定，造成
+  ///    "点一次只获焦不弹键盘"的现象。
+  ///
+  /// 本组件采用更克制的策略：tap outside 时不主动 unfocus，让 framework
+  /// 根据真正的焦点变更来管理键盘显隐。业务方如需"点空白处收起键盘"，
+  /// 可显式传入 onTapOutside 覆盖此默认值。
+  static void _defaultOnTapOutside(PointerDownEvent event) {}
 
   @override
   Widget build(BuildContext context) {
@@ -134,7 +155,8 @@ class TDInputView extends StatelessWidget {
       maxLines: maxLines,
       minLines: minLines,
       maxLength: maxLength,
-      onTapOutside: onTapOutside,
+      onTapOutside: onTapOutside ?? _defaultOnTapOutside,
+      autofillHints: autofillHints,
       selectionControls: selectionControls,
       contextMenuBuilder: contextMenuBuilder,
       style: textStyle,

--- a/tdesign-component/lib/src/components/input/td_input.dart
+++ b/tdesign-component/lib/src/components/input/td_input.dart
@@ -74,6 +74,8 @@ class TDInput extends StatelessWidget {
     this.selectionControls,
     this.contextMenuBuilder,
     this.enableInteractiveSelection,
+    this.autofillHints,
+    this.onLabelTap,
   }) : spacer = spacer ?? TDInputSpacer.generateDefault();
 
   /// 输入框宽度(TDCardStyle时必须设置该参数)
@@ -235,6 +237,18 @@ class TDInput extends StatelessWidget {
   /// 是否启用交互式选择
   final bool? enableInteractiveSelection;
 
+  /// 自动填充提示，例如密码框可传 `[AutofillHints.password]`，让系统/输入法
+  /// 识别为密码字段，配合 [AutofillGroup] 触发自动填充。
+  final Iterable<String>? autofillHints;
+
+  /// 点击左侧 leftIcon / leftLabel 区域时的回调。
+  ///
+  /// 默认值为 null，此时点击 label 区域会通过 [HitTestBehavior.translucent]
+  /// 穿透到下方输入框，使输入框获得焦点并弹出键盘（这是密码输入框场景下
+  /// 的常见预期）。若业务方需要拦截 label 点击事件（例如点 label 弹出帮助
+  /// 提示），可传入此回调。
+  final GestureTapCallback? onLabelTap;
+
   /// 获取输入框规格
   double getInputPadding() {
     switch (size) {
@@ -346,6 +360,12 @@ class TDInput extends StatelessWidget {
               SizedBox(
                 width: leftLabelWidth,
                 child: GestureDetector(
+                  // [issue #763] 加上 translucent 命中测试行为：当 onLabelTap
+                  // 未传时，让点击事件穿透到下方 TextField，避免 Android 上
+                  // 第一次 tap 只获焦不弹键盘的问题；同时显式传 onTap 让
+                  // GestureDetector 的命中行为可预期。
+                  behavior: HitTestBehavior.translucent,
+                  onTap: onLabelTap,
                   child: Row(
                     children: [
                       Visibility(
@@ -440,6 +460,7 @@ class TDInput extends StatelessWidget {
                       selectionControls: selectionControls,
                       contextMenuBuilder: contextMenuBuilder,
                       enableInteractiveSelection: enableInteractiveSelection,
+                      autofillHints: autofillHints,
                     ),
                     Visibility(
                       child: Container(
@@ -675,6 +696,7 @@ class TDInput extends StatelessWidget {
                         selectionControls: selectionControls,
                         contextMenuBuilder: contextMenuBuilder,
                         enableInteractiveSelection: enableInteractiveSelection,
+                        autofillHints: autofillHints,
                       ),
                     ),
                     Visibility(
@@ -796,6 +818,7 @@ class TDInput extends StatelessWidget {
               selectionControls: selectionControls,
               contextMenuBuilder: contextMenuBuilder,
               enableInteractiveSelection: enableInteractiveSelection,
+              autofillHints: autofillHints,
             ),
           ),
           Container(
@@ -890,6 +913,7 @@ class TDInput extends StatelessWidget {
                     selectionControls: selectionControls,
                     contextMenuBuilder: contextMenuBuilder,
                     enableInteractiveSelection: enableInteractiveSelection,
+                    autofillHints: autofillHints,
                   ),
                 ),
               ),

--- a/tdesign-component/test/input/td_input_test.dart
+++ b/tdesign-component/test/input/td_input_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tdesign_flutter/tdesign_flutter.dart';
+
+/// TDInput 密码输入框相关 Widget 测试
+///
+/// 覆盖 [issue #763](https://github.com/Tencent/tdesign-flutter/issues/763)
+/// 的修复点：
+/// 1. `obscureText: true` 正确透传到底层 TextField；
+/// 2. `autofillHints` 正确透传到底层 TextField；
+/// 3. label 区域 GestureDetector 使用 `HitTestBehavior.translucent`，
+///    确保点击事件不抢夺，不影响输入框获取焦点；
+/// 4. 默认 `onTapOutside` 不会主动 unfocus，从而保证多个 TDInput 之间
+///    切换焦点时键盘不会被错误收起。
+void main() {
+  group('TDInput obscureText (issue #763)', () {
+    testWidgets('obscureText: true 应正确透传到底层 TextField',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TDInput(
+              obscureText: true,
+              leftLabel: '密码',
+              hintText: '请输入密码',
+              needClear: false,
+            ),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.obscureText, isTrue,
+          reason: 'TDInput.obscureText 必须透传到底层 TextField');
+    });
+
+    testWidgets('autofillHints 应正确透传到底层 TextField',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AutofillGroup(
+              child: TDInput(
+                obscureText: true,
+                leftLabel: '密码',
+                autofillHints: const [AutofillHints.password],
+                needClear: false,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.autofillHints, equals(const [AutofillHints.password]),
+          reason: 'TDInput.autofillHints 必须透传到底层 TextField');
+    });
+
+    testWidgets('label 区域 GestureDetector 应使用 translucent 命中行为',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TDInput(
+              obscureText: true,
+              leftLabel: '密码',
+              hintText: '请输入密码',
+              needClear: false,
+            ),
+          ),
+        ),
+      );
+
+      // 在 label 区域至少存在一个 behavior == translucent 的 GestureDetector，
+      // 确保点击 label 区不会抢夺手势导致首次 tap 不弹键盘。
+      final detectors =
+          tester.widgetList<GestureDetector>(find.byType(GestureDetector));
+      final hasTranslucent = detectors
+          .any((d) => d.behavior == HitTestBehavior.translucent);
+      expect(hasTranslucent, isTrue,
+          reason: 'label 区域 GestureDetector 必须使用 HitTestBehavior.translucent，'
+              '避免抢夺 TextField 的点击手势导致首次 tap 不弹键盘');
+    });
+
+    testWidgets('未传 onTapOutside 时，TextField 应使用安全默认值（不主动 unfocus）',
+        (WidgetTester tester) async {
+      final focusA = FocusNode();
+      final focusB = FocusNode();
+      addTearDown(focusA.dispose);
+      addTearDown(focusB.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                TDInput(
+                  key: const Key('input-a'),
+                  obscureText: true,
+                  leftLabel: '密码A',
+                  focusNode: focusA,
+                  needClear: false,
+                ),
+                TDInput(
+                  key: const Key('input-b'),
+                  obscureText: true,
+                  leftLabel: '密码B',
+                  focusNode: focusB,
+                  needClear: false,
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // 模拟用户点击第一个输入框获取焦点
+      focusA.requestFocus();
+      await tester.pump();
+      expect(focusA.hasFocus, isTrue);
+
+      // 模拟用户切换到第二个输入框
+      focusB.requestFocus();
+      await tester.pump();
+
+      // 关键断言：两个 TextField 的 onTapOutside 都不是 null（即使用了
+      // TDInputView 的安全默认值），保证多个 TDInput 切换焦点时键盘行为正确。
+      final textFields =
+          tester.widgetList<TextField>(find.byType(TextField)).toList();
+      expect(textFields.length, 2);
+      for (final tf in textFields) {
+        expect(tf.onTapOutside, isNotNull,
+            reason: 'TDInputView 必须为 onTapOutside 提供不主动 unfocus 的安全默认值，'
+                '避免多个 TDInput 切换焦点时键盘被错误收起');
+      }
+    });
+
+    testWidgets('显式传入 onTapOutside 时应使用业务方提供的回调',
+        (WidgetTester tester) async {
+      var customCalled = false;
+      void customOnTapOutside(PointerDownEvent event) {
+        customCalled = true;
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TDInput(
+              obscureText: true,
+              leftLabel: '密码',
+              onTapOutside: customOnTapOutside,
+              needClear: false,
+            ),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      // 直接调用底层 TextField 的回调，验证业务方传入的 onTapOutside 被采用
+      textField.onTapOutside!(const PointerDownEvent());
+      expect(customCalled, isTrue,
+          reason: '业务方显式传入的 onTapOutside 必须覆盖默认值');
+    });
+
+    testWidgets('onLabelTap 默认 null 时点击 label 区域不抛错',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TDInput(
+              obscureText: true,
+              leftLabel: '密码',
+              needClear: false,
+            ),
+          ),
+        ),
+      );
+
+      // 找到带 leftLabel 文案的 TDText 并点击
+      await tester.tap(find.text('密码'), warnIfMissed: false);
+      await tester.pump();
+      // 不抛错即通过；命中行为由 translucent 保证可穿透到 TextField
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('显式传入 onLabelTap 时点击 label 区域应触发回调',
+        (WidgetTester tester) async {
+      var labelTapped = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TDInput(
+              obscureText: true,
+              leftLabel: '密码',
+              onLabelTap: () {
+                labelTapped = true;
+              },
+              needClear: false,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('密码'), warnIfMissed: false);
+      await tester.pump();
+      expect(labelTapped, isTrue,
+          reason: 'TDInput.onLabelTap 必须在点击 label 区域时被触发');
+    });
+  });
+}


### PR DESCRIPTION
Fixes the following issues reported in #763 on Android:
1. First tap on password TDInput only requests focus but does not show keyboard, requiring a second tap.
2. Switching focus between two TDInputs causes the keyboard to be dismissed instead of staying open.

Root causes:
- Label area GestureDetector did not declare HitTestBehavior, so the hit-test could absorb the first tap and prevent EditableText from showing the keyboard alongside requestFocus.
- TDInputView passed onTapOutside straight through to TextField; when callers do not provide one, Flutters default _defaultOnTapOutside unfocuses the current field, racing with the next fields requestFocus and causing the keyboard to flicker shut on Android.

Changes:
- TDInput: label-area GestureDetector now uses HitTestBehavior.translucent and forwards an explicit onLabelTap, so taps fall through to the underlying TextField when no label handler is supplied.
- TDInput / TDInputView: add new optional autofillHints parameter and forward it to TextField for proper system password autofill support.
- TDInputView: provide a no-op default onTapOutside so switching between multiple TDInputs no longer dismisses the soft keyboard. Callers can still override it to restore the dismiss-on-tap-outside behaviour.
- example: add a login-style demo with two consecutive password inputs to manually verify the fix.
- test: add the first input widget tests under test/input/ covering all fix points (7 cases, all passing).

### 🤔 这个 PR 的性质是？
> 勾选规则:
> 1.只要有新增参数，就勾选”新特性提交“
> 2.只修改内部bug，未新增参数，才勾选”日常 bug 修复“
> 3.其他选项视具体改动判断

- [ x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并x
- [ ] 其他

### 🔗 相关 Issue

<!--
- Closes #763 
-->

### 💡 需求背景和解决方案

<!--
## 本 PR 修复的问题

### 1. 两个 TDInput 之间切换焦点时，键盘不再被收起 ✅

**根因**：`TextField` 默认的 `onTapOutside` 会在指针落到输入框外部任意位置时调用 `focusNode.unfocus()`。当点击下一个 TDInput 时，前一个输入框的 `onTapOutside` 会先于新输入框的 `requestFocus` 触发，造成键盘在切换中途被收起。

**修复**：`TDInputView` 提供了一个空函数作为默认 `onTapOutside`。业务方如果仍需"点空白处收起键盘"的行为，可以显式传入 `onTapOutside` 覆盖默认值。

**验证情况**：
- ✅ iOS 17 通过
- ✅ Android MIUI（红米真机）通过

### 2. Label 区点击事件不再被 GestureDetector 吸走 ✅

**根因**：包裹 `leftLabel` 的 `GestureDetector` 没有声明 `HitTestBehavior`，在某些平台上会被命中测试视为不透明，吸走第一次 tap，导致点击 label 区时下方 `TextField` 收不到事件。

**修复**：显式声明 `HitTestBehavior.translucent`，并加上 `onLabelTap` 回调。当业务方未传 `onLabelTap` 时，点击事件会穿透到下方 `TextField`，触发获焦和弹键盘。

**验证情况**：✅ iOS 17 通过

### 3. 新增 `autofillHints` 参数 🆕

`TDInput` 和 `TDInputView` 新增可选参数 `autofillHints`，透传给底层 `TextField`。配合 `AutofillGroup` 使用，可以让密码框等字段触发系统级自动填充（例如 `[AutofillHints.password]`）。

### 4. 新增 `onLabelTap` 回调 🆕

允许业务方拦截 label 区域的点击事件（例如点 label 弹出帮助提示），未传时保持原有的"穿透到输入框"行为，向后兼容。

---

## ⚠️ 已知局限（非本 PR 可解决）

在 MIUI / HyperOS 上，即使是**裸** `TextField(obscureText: true)`，首次点击也需要点两次才能唤起键盘。我们做了三种原生 `TextField` 同页对照实验来定位根因：

| 输入框类型 | 首次点击是否弹键盘 |
|---|---|
| `TextField()` 普通文本框 | ✅ 一次弹起 |
| `TextField(obscureText: true)` | ❌ 要点两次 |
| `TextField(obscureText: true, keyboardType: TextInputType.visiblePassword)` | ❌ 要点两次 |

**结论**：这是 Flutter Engine 层（`TextInputPlugin.java`）与厂商 IME 的兼容性问题——MIUI 的 `InputMethodManager` 会静默忽略 `PASSWORD` `InputType` 的首次 show 请求，**无法在 Dart 组件层兜底**。该问题需要 Flutter Engine 上游修复，已分别追踪。

> 💡 issue #763 中提到的"切换两个密码框键盘被收起"这一诉求在 MIUI 上**已修复**；"首次点击不弹"这一诉求受上游 Engine 限制，不在本 PR 修复范围。

---

## 测试

- ✅ `test/input/td_input_test.dart` 新增 **7 个 widget test**，全部通过
- ✅ iOS 17 手动验证：7/7 场景通过
- ✅ Android（Pixel 模拟器）手动验证：两项修复都生效
- ✅ Android（红米 MIUI）手动验证：
  - 修复 #1（双密码框切换不收键盘）✅ 生效
  - 修复 #2（首次点击弹键盘）受上游 Engine bug 限制（已说明）

---

## Demo

`example` 工程的 TDInput 示例页新增 demo：**"登录场景：双密码框焦点切换不收键盘"**，方便手动验证修复 #1 的效果。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] pr目标分支为develop分支，请勿直接往main分支合并
- [ ] 标题格式为：`组件类名`: 修改描述（示例：`TBottomTabBar`: 修复iconText模式，底部溢出2.5像素）
- [ ] ”相关issue“处带上修复的issue链接
- [ ] 相关文档已补充或无须补充
