### PR TITLE
fix(TInput): password input keyboard issues on focus switch (#763)

### DIFF
--- a/tdesign-component/example/assets/api/action-sheet_api.md
+++ b/tdesign-component/example/assets/api/action-sheet_api.md
@@ -1,4 +1,23 @@
 ## API
+### TActionSheetItem
+#### 简介
+动作面板项目
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| badge | TBadge? | - | 角标 |
+| description | String? | - | 描述信息 |
+| disabled | bool | false | 是否禁用 |
+| group | String? | - | 分组，用于带描述多行滚动宫格 |
+| icon | Widget? | - | 图标 |
+| iconSize | double? | - | 图标大小 |
+| label | String | - | 标题 |
+| textStyle | TextStyle? | - | 标题样式 |
+
+```
+```
+
 ### TActionSheet
 #### 简介
 动作面板
@@ -35,22 +54,3 @@
 | showGridActionSheet |  |   required BuildContext context,  required List<TActionSheetItem> items,  TActionSheetAlign align,  String? cancelText,  bool showCancel,  TActionSheetItemCallback? onSelected,  bool showOverlay,  bool closeOnOverlayClick,  int count,  int rows,  double itemHeight,  double itemMinWidth,  bool scrollable,  bool showPagination,  VoidCallback? onCancel,  String? description,  VoidCallback? onClose,  bool useSafeArea, | 显示宫格类型面板 |
 | showGroupActionSheet |  |   required BuildContext context,  required List<TActionSheetItem> items,  TActionSheetAlign align,  String? cancelText,  bool showCancel,  TActionSheetItemCallback? onSelected,  bool showOverlay,  bool closeOnOverlayClick,  double itemHeight,  double itemMinWidth,  VoidCallback? onCancel,  VoidCallback? onClose,  bool useSafeArea, | 显示分组类型面板 |
 | showListActionSheet |  |   required BuildContext context,  required List<TActionSheetItem> items,  TActionSheetAlign align,  String? cancelText,  bool showCancel,  VoidCallback? onCancel,  TActionSheetItemCallback? onSelected,  bool showOverlay,  bool closeOnOverlayClick,  VoidCallback? onClose,  bool useSafeArea, | 显示列表类型面板 |
-
-```
-```
-
-### TActionSheetItem
-#### 简介
-动作面板项目
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| badge | TBadge? | - | 角标 |
-| description | String? | - | 描述信息 |
-| disabled | bool | false | 是否禁用 |
-| group | String? | - | 分组，用于带描述多行滚动宫格 |
-| icon | Widget? | - | 图标 |
-| iconSize | double? | - | 图标大小 |
-| label | String | - | 标题 |
-| textStyle | TextStyle? | - | 标题样式 |

--- a/tdesign-component/example/assets/api/button_api.md
+++ b/tdesign-component/example/assets/api/button_api.md
@@ -1,29 +1,4 @@
 ## API
-### TButtonStyle
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| backgroundColor | Color? | - | 背景颜色 |
-| frameColor | Color? | - | 边框颜色 |
-| frameWidth | double? | - | 边框宽度 |
-| gradient | Gradient? | - | 渐变背景色 |
-| radius | BorderRadiusGeometry? | - | 自定义圆角 |
-| textColor | Color? | - | 文字颜色 |
-
-
-#### 工厂构造方法
-
-| 名称  | 说明 |
-| --- |  --- |
-| TButtonStyle.generateFillStyleByTheme  | 生成不同主题的填充按钮样式 |
-| TButtonStyle.generateGhostStyleByTheme  | 生成不同主题的幽灵按钮样式 |
-| TButtonStyle.generateOutlineStyleByTheme  | 生成不同主题的描边按钮样式 |
-| TButtonStyle.generateTextStyleByTheme  | 生成不同主题的文本按钮样式 |
-
-```
-```
-
 ### TButton
 #### 默认构造方法
 
@@ -54,3 +29,28 @@
 | theme | TButtonTheme? | - | 主题 |
 | type | TButtonType | TButtonType.fill | 类型：填充，描边，文字 |
 | width | double? | - | 自定义宽度 |
+
+```
+```
+
+### TButtonStyle
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| backgroundColor | Color? | - | 背景颜色 |
+| frameColor | Color? | - | 边框颜色 |
+| frameWidth | double? | - | 边框宽度 |
+| gradient | Gradient? | - | 渐变背景色 |
+| radius | BorderRadiusGeometry? | - | 自定义圆角 |
+| textColor | Color? | - | 文字颜色 |
+
+
+#### 工厂构造方法
+
+| 名称  | 说明 |
+| --- |  --- |
+| TButtonStyle.generateFillStyleByTheme  | 生成不同主题的填充按钮样式 |
+| TButtonStyle.generateGhostStyleByTheme  | 生成不同主题的幽灵按钮样式 |
+| TButtonStyle.generateOutlineStyleByTheme  | 生成不同主题的描边按钮样式 |
+| TButtonStyle.generateTextStyleByTheme  | 生成不同主题的文本按钮样式 |

--- a/tdesign-component/example/assets/api/calendar_api.md
+++ b/tdesign-component/example/assets/api/calendar_api.md
@@ -1,32 +1,4 @@
 ## API
-### TCalendarStyle
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| cellDecoration | BoxDecoration? | - | 日期decoration |
-| cellPrefixStyle | TextStyle? | - | 日期前面的字符串的样式 |
-| cellStyle | TextStyle? | - | 日期样式 |
-| cellSuffixStyle | TextStyle? | - | 日期后面的字符串的样式 |
-| centreColor | Color? | - | 日期范围内背景样式 |
-| decoration |  | - |  |
-| monthTitleStyle | TextStyle? | - | body区域 年月文字样式 |
-| titleCloseColor | Color? | - | header区域 关闭图标的颜色 |
-| titleMaxLine | int? | - | header区域 [TCalendar.title]的行数 |
-| titleStyle | TextStyle? | - | header区域 [TCalendar.title]的样式 |
-| weekdayStyle | TextStyle? | - | header区域 周 文字样式 |
-
-
-#### 工厂构造方法
-
-| 名称  | 说明 |
-| --- |  --- |
-| TCalendarStyle.cellStyle  | 日期样式 |
-| TCalendarStyle.generateStyle  | 生成默认样式 |
-
-```
-```
-
 ### TCalendar
 #### 默认构造方法
 
@@ -69,10 +41,6 @@
 ```
 ```
 
-### TCalendarDataSource
-```
-```
-
 ### TCalendarPopup
 #### 默认构造方法
 
@@ -88,6 +56,38 @@
 | top | double? | - | 距离顶部的距离 |
 | visible | bool? | - | 默认是否显示日历 |
 
+```
+```
+
+### TCalendarStyle
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| cellDecoration | BoxDecoration? | - | 日期decoration |
+| cellPrefixStyle | TextStyle? | - | 日期前面的字符串的样式 |
+| cellStyle | TextStyle? | - | 日期样式 |
+| cellSuffixStyle | TextStyle? | - | 日期后面的字符串的样式 |
+| centreColor | Color? | - | 日期范围内背景样式 |
+| decoration |  | - |  |
+| monthTitleStyle | TextStyle? | - | body区域 年月文字样式 |
+| titleCloseColor | Color? | - | header区域 关闭图标的颜色 |
+| titleMaxLine | int? | - | header区域 [TCalendar.title]的行数 |
+| titleStyle | TextStyle? | - | header区域 [TCalendar.title]的样式 |
+| weekdayStyle | TextStyle? | - | header区域 周 文字样式 |
+
+
+#### 工厂构造方法
+
+| 名称  | 说明 |
+| --- |  --- |
+| TCalendarStyle.cellStyle  | 日期样式 |
+| TCalendarStyle.generateStyle  | 生成默认样式 |
+
+```
+```
+
+### TCalendarDataSource
 ```
 ```
 

--- a/tdesign-component/example/assets/api/cell_api.md
+++ b/tdesign-component/example/assets/api/cell_api.md
@@ -1,4 +1,43 @@
 ## API
+### TCell
+#### 简介
+单元格组件
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| align | TCellAlign? | TCellAlign.middle | 内容的对齐方式，默认居中对齐。可选项：top/middle/bottom |
+| arrow | bool? | false | 是否显示右侧箭头 |
+| bordered | bool? | true | 是否显示下边框，仅在TCellGroup组件下起作用 |
+| description | String? | - | 下方内容描述文字 |
+| descriptionWidget | Widget? | - | 下方内容描述组件 |
+| disabled | bool? | false | 禁用 |
+| height | double? | - | 高度 |
+| hover | bool? | true | 是否开启点击反馈 |
+| image | ImageProvider? | - | 主图 |
+| imageCircle | double? | 50 | 主图圆角，默认50（圆形） |
+| imageSize | double? | - | 主图尺寸 |
+| imageWidget | Widget? | - | 主图组件 |
+| key |  | - |  |
+| leftIcon | IconData? | - | 左侧图标，出现在单元格标题的左侧 |
+| leftIconWidget | Widget? | - | 左侧图标组件 |
+| note | String? | - | 和标题同行的说明文字 |
+| noteMaxLine | int | 1 | 说明文字组件 最大行数 |
+| noteMaxWidth | double? | - | 说明文字组件 最大宽度，超过部分显示省略号，防止文字溢出 |
+| noteWidget | Widget? | - | 说明文字组件 |
+| onClick | TCellClick? | - | 点击事件 |
+| onLongPress | TCellClick? | - | 长按事件 |
+| required | bool? | false | 是否显示表单必填星号 |
+| rightIcon | IconData? | - | 最右侧图标 |
+| rightIconWidget | Widget? | - | 最右侧图标组件 |
+| showBottomBorder | bool? | false | 是否显示下边框（建议TCellGroup组件下false，避免与bordered重叠） |
+| style | TCellStyle? | - | 自定义样式 |
+| title | String? | - | 标题 |
+| titleWidget | Widget? | - | 标题组件 |
+
+```
+```
+
 ### TCellGroup
 #### 简介
 单元格组组件
@@ -52,42 +91,3 @@
 | 名称  | 说明 |
 | --- |  --- |
 | TCellStyle.cellStyle  | 生成单元格默认样式 |
-
-```
-```
-
-### TCell
-#### 简介
-单元格组件
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| align | TCellAlign? | TCellAlign.middle | 内容的对齐方式，默认居中对齐。可选项：top/middle/bottom |
-| arrow | bool? | false | 是否显示右侧箭头 |
-| bordered | bool? | true | 是否显示下边框，仅在TCellGroup组件下起作用 |
-| description | String? | - | 下方内容描述文字 |
-| descriptionWidget | Widget? | - | 下方内容描述组件 |
-| disabled | bool? | false | 禁用 |
-| height | double? | - | 高度 |
-| hover | bool? | true | 是否开启点击反馈 |
-| image | ImageProvider? | - | 主图 |
-| imageCircle | double? | 50 | 主图圆角，默认50（圆形） |
-| imageSize | double? | - | 主图尺寸 |
-| imageWidget | Widget? | - | 主图组件 |
-| key |  | - |  |
-| leftIcon | IconData? | - | 左侧图标，出现在单元格标题的左侧 |
-| leftIconWidget | Widget? | - | 左侧图标组件 |
-| note | String? | - | 和标题同行的说明文字 |
-| noteMaxLine | int | 1 | 说明文字组件 最大行数 |
-| noteMaxWidth | double? | - | 说明文字组件 最大宽度，超过部分显示省略号，防止文字溢出 |
-| noteWidget | Widget? | - | 说明文字组件 |
-| onClick | TCellClick? | - | 点击事件 |
-| onLongPress | TCellClick? | - | 长按事件 |
-| required | bool? | false | 是否显示表单必填星号 |
-| rightIcon | IconData? | - | 最右侧图标 |
-| rightIconWidget | Widget? | - | 最右侧图标组件 |
-| showBottomBorder | bool? | false | 是否显示下边框（建议TCellGroup组件下false，避免与bordered重叠） |
-| style | TCellStyle? | - | 自定义样式 |
-| title | String? | - | 标题 |
-| titleWidget | Widget? | - | 标题组件 |

--- a/tdesign-component/example/assets/api/checkbox_api.md
+++ b/tdesign-component/example/assets/api/checkbox_api.md
@@ -1,26 +1,4 @@
 ## API
-### TCheckboxGroup
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| checkedIds | List<String>? | - | 勾选的CheckBox id列表 |
-| child |  | - |  |
-| contentDirection | TContentDirection? | - | 文字相对icon的方位 |
-| controller | TCheckboxGroupController? | - | 可以通过控制器操作勾选状态 |
-| customContentBuilder | ContentBuilder? | - | CheckBox完全自定义内容 |
-| customIconBuilder | IconBuilder? | - | 自定义选择icon的样式 |
-| key |  | - |  |
-| maxChecked | int? | - | 最多可以勾选多少 |
-| onChangeGroup | OnGroupChange? | - | 状态变化监听器 |
-| onOverloadChecked | VoidCallback? | - | 超过最大可勾选的个数 |
-| spacing | double? | - | CheckBoxicon和文字的距离 |
-| style | TCheckboxStyle? | - | CheckBox复选框样式：圆形或方形 |
-| titleMaxLine | int? | - | CheckBox标题的行数 |
-
-```
-```
-
 ### TCheckbox
 #### 默认构造方法
 
@@ -53,3 +31,25 @@
 | titleColor | Color? | - | 标题文字颜色 |
 | titleFont | Font? | - | 标题字体大小 |
 | titleMaxLine | int? | - | 标题的行数 |
+
+```
+```
+
+### TCheckboxGroup
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| checkedIds | List<String>? | - | 勾选的CheckBox id列表 |
+| child |  | - |  |
+| contentDirection | TContentDirection? | - | 文字相对icon的方位 |
+| controller | TCheckboxGroupController? | - | 可以通过控制器操作勾选状态 |
+| customContentBuilder | ContentBuilder? | - | CheckBox完全自定义内容 |
+| customIconBuilder | IconBuilder? | - | 自定义选择icon的样式 |
+| key |  | - |  |
+| maxChecked | int? | - | 最多可以勾选多少 |
+| onChangeGroup | OnGroupChange? | - | 状态变化监听器 |
+| onOverloadChecked | VoidCallback? | - | 超过最大可勾选的个数 |
+| spacing | double? | - | CheckBoxicon和文字的距离 |
+| style | TCheckboxStyle? | - | CheckBox复选框样式：圆形或方形 |
+| titleMaxLine | int? | - | CheckBox标题的行数 |

--- a/tdesign-component/example/assets/api/dialog_api.md
+++ b/tdesign-component/example/assets/api/dialog_api.md
@@ -1,25 +1,36 @@
 ## API
-### TImageDialog
+### TAlertDialog
 #### 默认构造方法
 
 | 参数 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
 | backgroundColor | Color? | - | 背景颜色 |
+| buttonStyle |  | TDialogButtonStyle.normal |  |
 | buttonWidget | Widget? | - | 自定义按钮 |
 | content | String? | - | 内容 |
 | contentColor | Color? | - | 内容颜色 |
+| contentMaxHeight | double | 0 | 内容的最大高度，默认为0，也就是不限制高度 |
 | contentWidget | Widget? | - | 内容Widget |
-| image | Image | - | 图片 |
-| imagePosition | TDialogImagePosition? | TDialogImagePosition.top | 图片位置 |
 | key |  | - |  |
 | leftBtn | TDialogButtonOptions? | - | 左侧按钮配置 |
-| padding | EdgeInsets? | - | 内容内边距 |
+| leftBtnAction |  Function()? | - | 左侧按钮默认点击 |
+| padding | EdgeInsets? | const EdgeInsets.fromLTRB(24, 32, 24, 0) | 内容内边距 |
 | radius | double | 12.0 | 圆角 |
 | rightBtn | TDialogButtonOptions? | - | 右侧按钮配置 |
+| rightBtnAction |  Function()? | - | 右侧按钮默认点击 |
 | showCloseButton | bool? | - | 显示右上角关闭按钮 |
 | title | String? | - | 标题 |
 | titleAlignment | AlignmentGeometry? | - | 标题对齐模式 |
 | titleColor | Color? | - | 标题颜色 |
+
+
+#### 工厂构造方法
+
+| 名称  | 说明 |
+| --- |  --- |
+| TAlertDialog.vertical  | 纵向按钮排列的对话框
+
+ [buttons]参数是必须的，纵向按钮默认样式都是[TButtonTheme.primary] |
 
 ```
 ```
@@ -48,6 +59,24 @@
 | titleAlignment | AlignmentGeometry? | - | 标题对齐模式 |
 | titleColor | Color? | - | 标题颜色 |
 | width |  | - |  |
+
+```
+```
+
+### TDialogButtonOptions
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| action |  Function()? | - | 点击操作 |
+| fontWeight | FontWeight? | - | 字体粗细 |
+| height | double? | - | 按钮高度 |
+| style | TButtonStyle? | - | 按钮样式 |
+| theme | TButtonTheme? | - | 按钮类型 |
+| title | String | - | 标题内容 |
+| titleColor | Color? | - | 标题颜色 |
+| titleSize | double? | - | 字体大小 |
+| type | TButtonType? | - | 按钮类型 |
 
 ```
 ```
@@ -154,56 +183,27 @@
 ```
 ```
 
-### TDialogButtonOptions
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| action |  Function()? | - | 点击操作 |
-| fontWeight | FontWeight? | - | 字体粗细 |
-| height | double? | - | 按钮高度 |
-| style | TButtonStyle? | - | 按钮样式 |
-| theme | TButtonTheme? | - | 按钮类型 |
-| title | String | - | 标题内容 |
-| titleColor | Color? | - | 标题颜色 |
-| titleSize | double? | - | 字体大小 |
-| type | TButtonType? | - | 按钮类型 |
-
-```
-```
-
-### TAlertDialog
+### TImageDialog
 #### 默认构造方法
 
 | 参数 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
 | backgroundColor | Color? | - | 背景颜色 |
-| buttonStyle |  | TDialogButtonStyle.normal |  |
 | buttonWidget | Widget? | - | 自定义按钮 |
 | content | String? | - | 内容 |
 | contentColor | Color? | - | 内容颜色 |
-| contentMaxHeight | double | 0 | 内容的最大高度，默认为0，也就是不限制高度 |
 | contentWidget | Widget? | - | 内容Widget |
+| image | Image | - | 图片 |
+| imagePosition | TDialogImagePosition? | TDialogImagePosition.top | 图片位置 |
 | key |  | - |  |
 | leftBtn | TDialogButtonOptions? | - | 左侧按钮配置 |
-| leftBtnAction |  Function()? | - | 左侧按钮默认点击 |
-| padding | EdgeInsets? | const EdgeInsets.fromLTRB(24, 32, 24, 0) | 内容内边距 |
+| padding | EdgeInsets? | - | 内容内边距 |
 | radius | double | 12.0 | 圆角 |
 | rightBtn | TDialogButtonOptions? | - | 右侧按钮配置 |
-| rightBtnAction |  Function()? | - | 右侧按钮默认点击 |
 | showCloseButton | bool? | - | 显示右上角关闭按钮 |
 | title | String? | - | 标题 |
 | titleAlignment | AlignmentGeometry? | - | 标题对齐模式 |
 | titleColor | Color? | - | 标题颜色 |
-
-
-#### 工厂构造方法
-
-| 名称  | 说明 |
-| --- |  --- |
-| TAlertDialog.vertical  | 纵向按钮排列的对话框
-
- [buttons]参数是必须的，纵向按钮默认样式都是[TButtonTheme.primary] |
 
 ```
 ```

--- a/tdesign-component/example/assets/api/drawer_api.md
+++ b/tdesign-component/example/assets/api/drawer_api.md
@@ -1,4 +1,34 @@
 ## API
+### TDrawer
+#### 简介
+抽屉组件
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| backgroundColor | Color? | - | 组件背景颜色 |
+| bordered | bool? | true | 是否显示边框 |
+| closeOnOverlayClick | bool? | true | 点击蒙层时是否关闭抽屉 |
+| contentWidget | Widget? | - | 自定义内容，优先级高于[items]/[footer]/[title] |
+| context | BuildContext | context | 上下文 |
+| drawerTop | double? | - | 距离顶部的距离 |
+| footer | Widget? | - | 抽屉的底部 |
+| hover | bool? | true | 是否开启点击反馈 |
+| isShowLastBordered | bool? | true | 是否显示最后一行分割线 |
+| items | List<TDrawerItem>? | - | 抽屉里的列表项 |
+| onClose | VoidCallback? | - | 关闭时触发 |
+| onItemClick | TDrawerItemClickCallback? | - | 点击抽屉里的列表项触发 |
+| placement | TDrawerPlacement? | TDrawerPlacement.right | 抽屉方向 |
+| showOverlay | bool? | true | 是否显示遮罩层 |
+| style | TCellStyle? | - | 列表自定义样式 |
+| title | String? | - | 抽屉的标题 |
+| titleWidget | Widget? | - | 抽屉的标题组件 |
+| visible | bool? | - | 组件是否可见 |
+| width | double? | 280 | 宽度 |
+
+```
+```
+
 ### TDrawerWidget
 #### 简介
 抽屉内容组件
@@ -34,33 +64,3 @@
 | content | Widget? | - | 完全自定义 |
 | icon | Widget? | - | 每列图标 |
 | title | String? | - | 每列标题 |
-
-```
-```
-
-### TDrawer
-#### 简介
-抽屉组件
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| backgroundColor | Color? | - | 组件背景颜色 |
-| bordered | bool? | true | 是否显示边框 |
-| closeOnOverlayClick | bool? | true | 点击蒙层时是否关闭抽屉 |
-| contentWidget | Widget? | - | 自定义内容，优先级高于[items]/[footer]/[title] |
-| context | BuildContext | context | 上下文 |
-| drawerTop | double? | - | 距离顶部的距离 |
-| footer | Widget? | - | 抽屉的底部 |
-| hover | bool? | true | 是否开启点击反馈 |
-| isShowLastBordered | bool? | true | 是否显示最后一行分割线 |
-| items | List<TDrawerItem>? | - | 抽屉里的列表项 |
-| onClose | VoidCallback? | - | 关闭时触发 |
-| onItemClick | TDrawerItemClickCallback? | - | 点击抽屉里的列表项触发 |
-| placement | TDrawerPlacement? | TDrawerPlacement.right | 抽屉方向 |
-| showOverlay | bool? | true | 是否显示遮罩层 |
-| style | TCellStyle? | - | 列表自定义样式 |
-| title | String? | - | 抽屉的标题 |
-| titleWidget | Widget? | - | 抽屉的标题组件 |
-| visible | bool? | - | 组件是否可见 |
-| width | double? | 280 | 宽度 |

--- a/tdesign-component/example/assets/api/dropdown-menu_api.md
+++ b/tdesign-component/example/assets/api/dropdown-menu_api.md
@@ -1,7 +1,29 @@
 ## API
-### TDropdownItemController
+### TDropdownMenu
 #### 简介
-下拉菜单控制器
+下拉菜单
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| arrowColor | Color? | - | 自定义箭头颜色 |
+| arrowIcon | IconData? | - | 自定义箭头图标 |
+| builder | TDropdownItemBuilder? | - | 下拉菜单构建器，优先级高于[items] |
+| closeOnClickOverlay | bool? | true | 是否在点击遮罩层后关闭菜单 |
+| decoration | Decoration? | - | 下拉菜单的装饰器 |
+| direction | TDropdownMenuDirection? | TDropdownMenuDirection.auto | 菜单展开方向（down、up、auto） |
+| duration | double? | 200.0 | 动画时长，毫秒 |
+| height | double? | 48 | menu的高度 |
+| isScrollable | bool? | false | 是否开启滚动列表 |
+| items | List<TDropdownItem>? | - | 下拉菜单 |
+| key |  | - |  |
+| labelBuilder | LabelBuilder? | - | 自定义标签内容 |
+| onMenuClosed | ValueChanged<int>? | - | 关闭菜单事件 |
+| onMenuOpened | ValueChanged<int>? | - | 展开菜单事件 |
+| showOverlay | bool? | true | 是否显示遮罩层 |
+| tabBarAlign | MainAxisAlignment? | MainAxisAlignment.center | [TDropdownItem.label]和[arrowIcon]/[TDropdownItem.arrowIcon]的对齐方式 |
+| width | double? | - | menu的宽度 |
+
 ```
 ```
 
@@ -52,27 +74,6 @@
 ```
 ```
 
-### TDropdownMenu
+### TDropdownItemController
 #### 简介
-下拉菜单
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| arrowColor | Color? | - | 自定义箭头颜色 |
-| arrowIcon | IconData? | - | 自定义箭头图标 |
-| builder | TDropdownItemBuilder? | - | 下拉菜单构建器，优先级高于[items] |
-| closeOnClickOverlay | bool? | true | 是否在点击遮罩层后关闭菜单 |
-| decoration | Decoration? | - | 下拉菜单的装饰器 |
-| direction | TDropdownMenuDirection? | TDropdownMenuDirection.auto | 菜单展开方向（down、up、auto） |
-| duration | double? | 200.0 | 动画时长，毫秒 |
-| height | double? | 48 | menu的高度 |
-| isScrollable | bool? | false | 是否开启滚动列表 |
-| items | List<TDropdownItem>? | - | 下拉菜单 |
-| key |  | - |  |
-| labelBuilder | LabelBuilder? | - | 自定义标签内容 |
-| onMenuClosed | ValueChanged<int>? | - | 关闭菜单事件 |
-| onMenuOpened | ValueChanged<int>? | - | 展开菜单事件 |
-| showOverlay | bool? | true | 是否显示遮罩层 |
-| tabBarAlign | MainAxisAlignment? | MainAxisAlignment.center | [TDropdownItem.label]和[arrowIcon]/[TDropdownItem.arrowIcon]的对齐方式 |
-| width | double? | - | menu的宽度 |
+下拉菜单控制器

--- a/tdesign-component/example/assets/api/form_api.md
+++ b/tdesign-component/example/assets/api/form_api.md
@@ -1,4 +1,33 @@
 ## API
+### TForm
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| btnGroup | List<Widget>? | - | 表单按钮组 |
+| colon | bool? | false | 是否在表单标签字段右侧显示冒号 |
+| data | Map<String, dynamic> | - | 表单数据 |
+| disabled | bool | false | 是否禁用整个表单 |
+| errorMessage | Object? | - | 表单信息错误信息配置 |
+| formContentAlign | TextAlign | TextAlign.left | 表单内容对齐方式: 左对齐、右对齐、居中对齐 |
+| formController | FormController? | - | 表单控制器 |
+| formLabelAlign | TextAlign? | TextAlign.left | 表单字段标签的对齐方式： |
+| formShowErrorMessage | bool? | true | 校验不通过时，是否显示错误提示信息，统一控制全部表单项 |
+| isHorizontal | bool | true | 表单排列方式是否为 水平方向 |
+| items | List<TFormItem> | - | 表单内容 items |
+| key |  | - |  |
+| labelWidth | double? | 20.0 | 可以整体设置 label 标签宽度 |
+| onReset | Function? | - | 表单重置时触发 |
+| onSubmit | Function | - | 表单提交时触发 |
+| preventSubmitDefault | bool? | true | 是否阻止表单提交默认事件（表单提交默认事件会刷新页面） |
+| requiredMark | bool? | true | 是否显示必填符号（*），默认显示 |
+| rules | Map<String, TFormValidation> | - | 整个表单字段校验规则 |
+| scrollToFirstError | String? | - | 表单校验不通过时，是否自动滚动到第一个校验不通过的字段，平滑滚动或是瞬间直达。 |
+| submitWithWarningMessage | bool? | false | 【讨论中】当校验结果只有告警信息时，是否触发 submit 提交事件 |
+
+```
+```
+
 ### TFormItem
 #### 默认构造方法
 
@@ -39,32 +68,3 @@
 | errorMessage | String | - | 错误提示信息 |
 | type | TFormItemType | - | 校验对象的类型 |
 | validate | String? Function(dynamic) | - | 校验方法 |
-
-```
-```
-
-### TForm
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| btnGroup | List<Widget>? | - | 表单按钮组 |
-| colon | bool? | false | 是否在表单标签字段右侧显示冒号 |
-| data | Map<String, dynamic> | - | 表单数据 |
-| disabled | bool | false | 是否禁用整个表单 |
-| errorMessage | Object? | - | 表单信息错误信息配置 |
-| formContentAlign | TextAlign | TextAlign.left | 表单内容对齐方式: 左对齐、右对齐、居中对齐 |
-| formController | FormController? | - | 表单控制器 |
-| formLabelAlign | TextAlign? | TextAlign.left | 表单字段标签的对齐方式： |
-| formShowErrorMessage | bool? | true | 校验不通过时，是否显示错误提示信息，统一控制全部表单项 |
-| isHorizontal | bool | true | 表单排列方式是否为 水平方向 |
-| items | List<TFormItem> | - | 表单内容 items |
-| key |  | - |  |
-| labelWidth | double? | 20.0 | 可以整体设置 label 标签宽度 |
-| onReset | Function? | - | 表单重置时触发 |
-| onSubmit | Function | - | 表单提交时触发 |
-| preventSubmitDefault | bool? | true | 是否阻止表单提交默认事件（表单提交默认事件会刷新页面） |
-| requiredMark | bool? | true | 是否显示必填符号（*），默认显示 |
-| rules | Map<String, TFormValidation> | - | 整个表单字段校验规则 |
-| scrollToFirstError | String? | - | 表单校验不通过时，是否自动滚动到第一个校验不通过的字段，平滑滚动或是瞬间直达。 |
-| submitWithWarningMessage | bool? | false | 【讨论中】当校验结果只有告警信息时，是否触发 submit 提交事件 |

--- a/tdesign-component/example/assets/api/image-viewer_api.md
+++ b/tdesign-component/example/assets/api/image-viewer_api.md
@@ -1,4 +1,15 @@
 ## API
+### TImageViewer
+
+#### 静态方法
+
+| 名称 | 返回类型 | 参数 | 说明 |
+| --- | --- | --- | --- |
+| showImageViewer |  |   required BuildContext context,  required List<dynamic> images,  List<String>? labels,  bool? closeBtn,  bool? deleteBtn,  bool? showIndex,  bool? loop,  bool? autoplay,  int? duration,  Color? bgColor,  Color? navBarBgColor,  Color? iconColor,  TextStyle? labelStyle,  TextStyle? indexStyle,  Color? modalBarrierColor,  bool? barrierDismissible,  int? defaultIndex,  double? width,  double? height,  OnIndexChange? onIndexChange,  OnClose? onClose,  OnDelete? onDelete,  bool? ignoreDeleteError,  OnImageTap? onTap,  OnLongPress? onLongPress,  LeftItemBuilder? leftItemBuilder,  RightItemBuilder? rightItemBuilder, | 显示图片预览 |
+
+```
+```
+
 ### TImageViewerWidget
 #### 默认构造方法
 
@@ -29,14 +40,3 @@
 | rightItemBuilder | RightItemBuilder? | - | 右侧自定义操作 |
 | showIndex | bool? | - | 是否显示页码 |
 | width | double? | - | 图片宽度 |
-
-```
-```
-
-### TImageViewer
-
-#### 静态方法
-
-| 名称 | 返回类型 | 参数 | 说明 |
-| --- | --- | --- | --- |
-| showImageViewer |  |   required BuildContext context,  required List<dynamic> images,  List<String>? labels,  bool? closeBtn,  bool? deleteBtn,  bool? showIndex,  bool? loop,  bool? autoplay,  int? duration,  Color? bgColor,  Color? navBarBgColor,  Color? iconColor,  TextStyle? labelStyle,  TextStyle? indexStyle,  Color? modalBarrierColor,  bool? barrierDismissible,  int? defaultIndex,  double? width,  double? height,  OnIndexChange? onIndexChange,  OnClose? onClose,  OnDelete? onDelete,  bool? ignoreDeleteError,  OnImageTap? onTap,  OnLongPress? onLongPress,  LeftItemBuilder? leftItemBuilder,  RightItemBuilder? rightItemBuilder, | 显示图片预览 |

--- a/tdesign-component/example/assets/api/indexes_api.md
+++ b/tdesign-component/example/assets/api/indexes_api.md
@@ -1,4 +1,28 @@
 ## API
+### TIndexes
+#### 简介
+索引
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| builderAnchor | Widget? Function(BuildContext context, String index, bool isPinnedToTop)? | - | 锚点自定义构建 |
+| builderContent | Widget? Function(BuildContext context, String index) | - | 内容自定义构建 |
+| builderIndex | Widget Function(BuildContext context, String index, bool isActive)? | - | 索引文本自定义构建，包括索引激活左侧提示 |
+| capsuleTheme | bool? | false | 锚点是否为胶囊式样式 |
+| indexList | List<String>? | - | 索引字符列表。不传默认 A-Z |
+| indexListMaxHeight | double? | 0.8 | 索引列表最大高度（父容器高度的百分比，默认 0.8） |
+| key |  | - |  |
+| onChange | void Function(String index)? | - | 索引发生变更时触发事件 |
+| onSelect | void Function(String index)? | - | 点击侧边栏时触发事件 |
+| reverse | bool? | false | 反方向滚动置顶 |
+| scrollController | ScrollController? | - | 滚动控制器 |
+| sticky | bool? | true | 锚点是否吸顶 |
+| stickyOffset | double? | 0 | 锚点吸顶时与顶部的距离 |
+
+```
+```
+
 ### TIndexesAnchor
 #### 简介
 索引锚点
@@ -29,27 +53,3 @@
 | indexListMaxHeight | double | 0.8 | 索引列表最大高度（父容器高度的百分比，默认0.8） |
 | key |  | - |  |
 | onSelect | void Function(String newIndex, String oldIndex) | - | 点击侧边栏时触发事件 |
-
-```
-```
-
-### TIndexes
-#### 简介
-索引
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| builderAnchor | Widget? Function(BuildContext context, String index, bool isPinnedToTop)? | - | 锚点自定义构建 |
-| builderContent | Widget? Function(BuildContext context, String index) | - | 内容自定义构建 |
-| builderIndex | Widget Function(BuildContext context, String index, bool isActive)? | - | 索引文本自定义构建，包括索引激活左侧提示 |
-| capsuleTheme | bool? | false | 锚点是否为胶囊式样式 |
-| indexList | List<String>? | - | 索引字符列表。不传默认 A-Z |
-| indexListMaxHeight | double? | 0.8 | 索引列表最大高度（父容器高度的百分比，默认 0.8） |
-| key |  | - |  |
-| onChange | void Function(String index)? | - | 索引发生变更时触发事件 |
-| onSelect | void Function(String index)? | - | 点击侧边栏时触发事件 |
-| reverse | bool? | false | 反方向滚动置顶 |
-| scrollController | ScrollController? | - | 滚动控制器 |
-| sticky | bool? | true | 锚点是否吸顶 |
-| stickyOffset | double? | 0 | 锚点吸顶时与顶部的距离 |

--- a/tdesign-component/example/assets/api/input_api.md
+++ b/tdesign-component/example/assets/api/input_api.md
@@ -6,6 +6,7 @@
 | --- | --- | --- | --- |
 | additionInfo | String? | '' | 错误提示信息 |
 | additionInfoColor | Color? | - | 错误提示颜色 |
+| autofillHints | Iterable<String>? | - | 自动填充提示，例如密码框可传 `[AutofillHints.password]`，让系统/输入法 |
 | autofocus | bool | false | 是否自动获取焦点 |
 | backgroundColor | Color? | - | 输入框背景色 |
 | cardStyle | TCardStyle? | - | 卡片默认样式 |
@@ -43,6 +44,7 @@
 | onChanged | ValueChanged<String>? | - | 输入文本变化时回调 |
 | onClearTap | GestureTapCallback? | - | 右侧删除点击 |
 | onEditingComplete | VoidCallback? | - | 点击键盘完成按钮时触发的回调 |
+| onLabelTap | GestureTapCallback? | - | 点击左侧 leftIcon / leftLabel 区域时的回调。 |
 | onSubmitted | ValueChanged<String>? | - | 点击键盘完成按钮时触发的回调, 参数值为输入的内容 |
 | onTapOutside | TapRegionCallback? | - | 点击输入框外部区域回调 |
 | readOnly | bool | false | 是否只读 |

--- a/tdesign-component/example/assets/api/message_api.md
+++ b/tdesign-component/example/assets/api/message_api.md
@@ -1,28 +1,4 @@
 ## API
-### MessageLink
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| color | Color? | - | 颜色 |
-| name | String | - | 名称 |
-| uri | Uri? | - | 资源链接 |
-
-```
-```
-
-### MessageMarquee
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| delay | int? | - | 延迟时间(毫秒) |
-| loop | int? | - | 循环次数 |
-| speed | int? | - | 速度 |
-
-```
-```
-
 ### TMessage
 #### 默认构造方法
 
@@ -48,3 +24,27 @@
 | 名称 | 返回类型 | 参数 | 说明 |
 | --- | --- | --- | --- |
 | showMessage |  |   required BuildContext context,  String? content,  bool? visible,  int? duration,  dynamic closeBtn,  dynamic icon,  dynamic link,  MessageMarquee? marquee,  List<double>? offset,  MessageTheme? theme,  VoidCallback? onCloseBtnClick,  VoidCallback? onDurationEnd,  VoidCallback? onLinkClick, |  |
+
+```
+```
+
+### MessageMarquee
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| delay | int? | - | 延迟时间(毫秒) |
+| loop | int? | - | 循环次数 |
+| speed | int? | - | 速度 |
+
+```
+```
+
+### MessageLink
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| color | Color? | - | 颜色 |
+| name | String | - | 名称 |
+| uri | Uri? | - | 资源链接 |

--- a/tdesign-component/example/assets/api/notice-bar_api.md
+++ b/tdesign-component/example/assets/api/notice-bar_api.md
@@ -1,28 +1,4 @@
 ## API
-### TNoticeBarStyle
-#### 简介
-公告栏样式
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| backgroundColor | Color? | - | 公告栏背景色 |
-| context | BuildContext? | - | 上下文 |
-| leftIconColor | Color? | - | 公告栏左侧图标颜色 |
-| padding | EdgeInsetsGeometry? | - | 公告栏内边距 |
-| rightIconColor | Color? | - | 公告栏右侧图标颜色 |
-| textStyle | TextStyle? | - | 公告栏内容样式 |
-
-
-#### 工厂构造方法
-
-| 名称  | 说明 |
-| --- |  --- |
-| TNoticeBarStyle.generateTheme  | 根据主题生成样式 |
-
-```
-```
-
 ### TNoticeBar
 #### 简介
 
@@ -46,3 +22,27 @@
 | style | TNoticeBarStyle? | - | 公告栏样式 [TNoticeBarStyle] |
 | suffixIcon | IconData? | - | 右侧图标 |
 | theme | TNoticeBarTheme? | TNoticeBarTheme.info | 主题 |
+
+```
+```
+
+### TNoticeBarStyle
+#### 简介
+公告栏样式
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| backgroundColor | Color? | - | 公告栏背景色 |
+| context | BuildContext? | - | 上下文 |
+| leftIconColor | Color? | - | 公告栏左侧图标颜色 |
+| padding | EdgeInsetsGeometry? | - | 公告栏内边距 |
+| rightIconColor | Color? | - | 公告栏右侧图标颜色 |
+| textStyle | TextStyle? | - | 公告栏内容样式 |
+
+
+#### 工厂构造方法
+
+| 名称  | 说明 |
+| --- |  --- |
+| TNoticeBarStyle.generateTheme  | 根据主题生成样式 |

--- a/tdesign-component/example/assets/api/picker_api.md
+++ b/tdesign-component/example/assets/api/picker_api.md
@@ -1,27 +1,4 @@
 ## API
-### TPickerOption
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| disabled | bool | false | 是否禁用（不可选中/置灰显示），默认 false |
-| label | String | - | 展示文字（可包含 emoji、单位、国际化等） |
-| value | dynamic | - | 业务值（onChange 回调返回此字段） |
-
-```
-```
-
-### TPickerValue
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| indexes | List<int> | - | 每列选中项的索引 |
-| selectedOptions | List<TPickerOption> | - | 每列选中的完整 option |
-
-```
-```
-
 ### TPicker
 #### 默认构造方法
 
@@ -47,7 +24,39 @@
 ```
 ```
 
-### TPickerItems
+### TPickerOption
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| disabled | bool | false | 是否禁用（不可选中/置灰显示），默认 false |
+| label | String | - | 展示文字（可包含 emoji、单位、国际化等） |
+| value | dynamic | - | 业务值（onChange 回调返回此字段） |
+
+```
+```
+
+### TPickerValue
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| indexes | List<int> | - | 每列选中项的索引 |
+| selectedOptions | List<TPickerOption> | - | 每列选中的完整 option |
+
+```
+```
+
+### TPickerLoadEvent
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| column | int | - | 触发事件的列索引（0 表示第一列） |
+| displayedCount | int | - | 当前列已展示的选项总数 |
+| parentValue | dynamic | - | 当前列的父级选中值（联动模式下使用） |
+| remaining | int | - | 距底部剩余的选项数（业务可用此值做"接近底部时加载"判断） |
+
 ```
 ```
 
@@ -99,6 +108,10 @@
 ```
 ```
 
+### TPickerItems
+```
+```
+
 ### TPickerKeys
 #### 默认构造方法
 
@@ -108,16 +121,3 @@
 | disabled | String | 'disabled' | 禁用标记对应的字段名，默认 `disabled` |
 | label | String | 'label' | 展示文案对应的字段名，默认 `label` |
 | value | String | 'value' | 业务值对应的字段名，默认 `value` |
-
-```
-```
-
-### TPickerLoadEvent
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| column | int | - | 触发事件的列索引（0 表示第一列） |
-| displayedCount | int | - | 当前列已展示的选项总数 |
-| parentValue | dynamic | - | 当前列的父级选中值（联动模式下使用） |
-| remaining | int | - | 距底部剩余的选项数（业务可用此值做"接近底部时加载"判断） |

--- a/tdesign-component/example/assets/api/popover_api.md
+++ b/tdesign-component/example/assets/api/popover_api.md
@@ -1,4 +1,17 @@
 ## API
+### TPopover
+#### 简介
+
+
+#### 静态方法
+
+| 名称 | 返回类型 | 参数 | 说明 |
+| --- | --- | --- | --- |
+| showPopover |  |   required BuildContext context,  String? content,  Widget? contentWidget,  double offset,  TPopoverTheme? theme,  bool closeOnClickOutside,  TPopoverPlacement? placement,  bool? showArrow,  double arrowSize,  EdgeInsetsGeometry? padding,  double? width,  double? height,  Color? overlayColor,  OnTap? onTap,  OnLongTap? onLongTap,  BorderRadius? radius, |  |
+
+```
+```
+
 ### TPopoverWidget
 #### 简介
 
@@ -21,16 +34,3 @@
 | showArrow | bool? | true | 是否显示浮层箭头 |
 | theme | TPopoverTheme? | - | 弹出气泡主题 |
 | width | double? | - | 内容宽度（包含padding，实际高度：height - paddingLeft - paddingRight） |
-
-```
-```
-
-### TPopover
-#### 简介
-
-
-#### 静态方法
-
-| 名称 | 返回类型 | 参数 | 说明 |
-| --- | --- | --- | --- |
-| showPopover |  |   required BuildContext context,  String? content,  Widget? contentWidget,  double offset,  TPopoverTheme? theme,  bool closeOnClickOutside,  TPopoverPlacement? placement,  bool? showArrow,  double arrowSize,  EdgeInsetsGeometry? padding,  double? width,  double? height,  Color? overlayColor,  OnTap? onTap,  OnLongTap? onLongTap,  BorderRadius? radius, |  |

--- a/tdesign-component/example/assets/api/popup_api.md
+++ b/tdesign-component/example/assets/api/popup_api.md
@@ -1,4 +1,30 @@
 ## API
+### TSlidePopupRoute
+#### 简介
+从屏幕的某个方向滑动弹出的Dialog框的路由，比如从顶部、底部、左、右滑出页面
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| barrierClick | VoidCallback? | - | 蒙层点击事件，仅在[modalBarrierFull]为false时触发 |
+| barrierLabel |  | - |  |
+| builder | WidgetBuilder | - | 控件构建器 |
+| close | VoidCallback? | - | 关闭前事件 |
+| focusMove | bool | false | 是否有输入框获取焦点时整体平移避免输入框被遮挡 |
+| isDismissible | bool | true | 点击蒙层能否关闭 |
+| modalBarrierColor | Color? | Colors.black54 | 蒙层颜色 |
+| modalBarrierFull | bool | false | 是否全屏显示蒙层 |
+| modalHeight | double? | - | 弹出框高度 |
+| modalLeft | double? | 0 | 弹出框左侧距离 |
+| modalTop | double? | 0 | 弹出框顶部距离 |
+| modalWidth | double? | - | 弹出框宽度 |
+| open | VoidCallback? | - | 打开前事件 |
+| opened | VoidCallback? | - | 打开后事件 |
+| slideTransitionFrom | SlideTransitionFrom | SlideTransitionFrom.bottom | 设置从屏幕的哪个方向滑出 |
+
+```
+```
+
 ### TPopupBottomDisplayPanel
 #### 简介
 右上角带关闭的底部浮层面板
@@ -69,29 +95,3 @@
 | closeUnderBottom | bool | false | 关闭按钮是否在视图框下方 |
 | key |  | - |  |
 | radius | double? | - | 圆角 |
-
-```
-```
-
-### TSlidePopupRoute
-#### 简介
-从屏幕的某个方向滑动弹出的Dialog框的路由，比如从顶部、底部、左、右滑出页面
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| barrierClick | VoidCallback? | - | 蒙层点击事件，仅在[modalBarrierFull]为false时触发 |
-| barrierLabel |  | - |  |
-| builder | WidgetBuilder | - | 控件构建器 |
-| close | VoidCallback? | - | 关闭前事件 |
-| focusMove | bool | false | 是否有输入框获取焦点时整体平移避免输入框被遮挡 |
-| isDismissible | bool | true | 点击蒙层能否关闭 |
-| modalBarrierColor | Color? | Colors.black54 | 蒙层颜色 |
-| modalBarrierFull | bool | false | 是否全屏显示蒙层 |
-| modalHeight | double? | - | 弹出框高度 |
-| modalLeft | double? | 0 | 弹出框左侧距离 |
-| modalTop | double? | 0 | 弹出框顶部距离 |
-| modalWidth | double? | - | 弹出框宽度 |
-| open | VoidCallback? | - | 打开前事件 |
-| opened | VoidCallback? | - | 打开后事件 |
-| slideTransitionFrom | SlideTransitionFrom | SlideTransitionFrom.bottom | 设置从屏幕的哪个方向滑出 |

--- a/tdesign-component/example/assets/api/side-bar_api.md
+++ b/tdesign-component/example/assets/api/side-bar_api.md
@@ -1,20 +1,4 @@
 ## API
-### TSideBarItem
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| badge | TBadge? | - | 徽标 |
-| disabled | bool | false | 是否禁用 |
-| icon | IconData? | - | 图标 |
-| key |  | - |  |
-| label | String | '' | 标签 |
-| textStyle | TextStyle? | - | 标签样式 |
-| value | int | -1 | 值 |
-
-```
-```
-
 ### TSideBar
 #### 默认构造方法
 
@@ -37,3 +21,19 @@
 | unSelectedBgColor | Color? | - | 未选择的背景颜色 |
 | unSelectedColor | Color? | - | 未选中颜色 |
 | value | int? | - | 选项值 |
+
+```
+```
+
+### TSideBarItem
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| badge | TBadge? | - | 徽标 |
+| disabled | bool | false | 是否禁用 |
+| icon | IconData? | - | 图标 |
+| key |  | - |  |
+| label | String | '' | 标签 |
+| textStyle | TextStyle? | - | 标签样式 |
+| value | int | -1 | 值 |

--- a/tdesign-component/example/assets/api/skeleton_api.md
+++ b/tdesign-component/example/assets/api/skeleton_api.md
@@ -1,4 +1,24 @@
 ## API
+### TSkeleton
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| animation | TSkeletonAnimation? | - | 动画效果 |
+| delay | int | 0 | 延迟显示加载时间 |
+| key |  | - |  |
+| theme |  | TSkeletonTheme.text |  |
+
+
+#### 工厂构造方法
+
+| 名称  | 说明 |
+| --- |  --- |
+| TSkeleton.fromRowCol  | 从行列框架创建骨架屏 |
+
+```
+```
+
 ### TSkeletonRowColStyle
 #### 默认构造方法
 
@@ -61,23 +81,3 @@
 | TSkeletonRowColObj.rect  | 矩形 |
 | TSkeletonRowColObj.spacer  | 空白占位符 |
 | TSkeletonRowColObj.text  | 文本 |
-
-```
-```
-
-### TSkeleton
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| animation | TSkeletonAnimation? | - | 动画效果 |
-| delay | int | 0 | 延迟显示加载时间 |
-| key |  | - |  |
-| theme |  | TSkeletonTheme.text |  |
-
-
-#### 工厂构造方法
-
-| 名称  | 说明 |
-| --- |  --- |
-| TSkeleton.fromRowCol  | 从行列框架创建骨架屏 |

--- a/tdesign-component/example/assets/api/steps_api.md
+++ b/tdesign-component/example/assets/api/steps_api.md
@@ -1,19 +1,4 @@
 ## API
-### TStepsItemData
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| content | String? | - | 内容 |
-| customContent | Widget? | - | 自定义内容 |
-| customTitle | Widget? | - | 自定义标题 |
-| errorIcon | IconData? | - | 失败图标 |
-| successIcon | IconData? | - | 成功图标 |
-| title | String? | - | 标题 |
-
-```
-```
-
 ### TSteps
 #### 默认构造方法
 
@@ -27,3 +12,18 @@
 | status | TStepsStatus | TStepsStatus.success | 步骤条状态 |
 | steps | List<TStepsItemData> | - | 步骤条数据 |
 | verticalSelect | bool | false | 步骤条垂直自定义步骤条选择模式 |
+
+```
+```
+
+### TStepsItemData
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| content | String? | - | 内容 |
+| customContent | Widget? | - | 自定义内容 |
+| customTitle | Widget? | - | 自定义标题 |
+| errorIcon | IconData? | - | 失败图标 |
+| successIcon | IconData? | - | 成功图标 |
+| title | String? | - | 标题 |

--- a/tdesign-component/example/assets/api/swiper_api.md
+++ b/tdesign-component/example/assets/api/swiper_api.md
@@ -1,4 +1,19 @@
 ## API
+### TSwiperPagination
+#### 简介
+TDesign风格的Swiper指示器样式，与flutter_swiper的Swiper结合使用
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| alignment | Alignment? | - | 当 scrollDirection== Axis.horizontal 时，默认Alignment.bottomCenter |
+| builder | SwiperPlugin | TSwiperPagination.dots | 具体样式 |
+| key | Key? | - |  |
+| margin | EdgeInsetsGeometry | const EdgeInsets.all(10.0) | 指示器和container之间的距离 |
+
+```
+```
+
 ### TPageTransformer
 #### 简介
 TD默认PageTransformer
@@ -17,18 +32,3 @@ TD默认PageTransformer
 | --- |  --- |
 | TPageTransformer.margin  | 普通margin的卡片式 |
 | TPageTransformer.scaleAndFade  | 缩放或透明的卡片式 |
-
-```
-```
-
-### TSwiperPagination
-#### 简介
-TDesign风格的Swiper指示器样式，与flutter_swiper的Swiper结合使用
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| alignment | Alignment? | - | 当 scrollDirection== Axis.horizontal 时，默认Alignment.bottomCenter |
-| builder | SwiperPlugin | TSwiperPagination.dots | 具体样式 |
-| key | Key? | - |  |
-| margin | EdgeInsetsGeometry | const EdgeInsets.all(10.0) | 指示器和container之间的距离 |

--- a/tdesign-component/example/assets/api/tab-bar_api.md
+++ b/tdesign-component/example/assets/api/tab-bar_api.md
@@ -1,36 +1,4 @@
 ## API
-### BadgeConfig
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| badgeRightOffset | double? | - | 消息右侧偏移量 |
-| badgeTopOffset | double? | - | 消息顶部偏移量 |
-| showBadge | bool | - | 是否展示消息 |
-| tBadge | TBadge? | - | 消息样式（未设置但 showBadge 为 true，则默认使用红点） |
-
-```
-```
-
-### TBottomTabBarTabConfig
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| allowMultipleTaps | bool | false | onTap 方法允许点击多次 |
-| badgeConfig | BadgeConfig? | - | 消息配置 |
-| onLongPress | GestureLongPressCallback? | - | 长按事件 |
-| onTap | GestureTapCallback? | - | tab点击事件 |
-| popUpButtonConfig | TBottomTabBarPopUpBtnConfig? | - | 弹窗配置 |
-| selectedIcon | Widget? | - | 选中时图标 |
-| selectTabTextStyle | TextStyle? | - | 文本已选择样式 basicType为text时必填 |
-| tabText | String? | - | tab 文本 |
-| unselectedIcon | Widget? | - | 未选中时图标 |
-| unselectTabTextStyle | TextStyle? | - | 文本未选择样式 basicType为text时必填 |
-
-```
-```
-
 ### TBottomTabBar
 #### 默认构造方法
 
@@ -59,6 +27,38 @@
 | unselectedBgColor | Color? | - | 未选中时背景颜色 |
 | useSafeArea | bool | true | 使用安全区域 |
 | useVerticalDivider | bool? | - | 是否使用竖线分隔（如果选项样式为 label，则强制为 false） |
+
+```
+```
+
+### BadgeConfig
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| badgeRightOffset | double? | - | 消息右侧偏移量 |
+| badgeTopOffset | double? | - | 消息顶部偏移量 |
+| showBadge | bool | - | 是否展示消息 |
+| tBadge | TBadge? | - | 消息样式（未设置但 showBadge 为 true，则默认使用红点） |
+
+```
+```
+
+### TBottomTabBarTabConfig
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| allowMultipleTaps | bool | false | onTap 方法允许点击多次 |
+| badgeConfig | BadgeConfig? | - | 消息配置 |
+| onLongPress | GestureLongPressCallback? | - | 长按事件 |
+| onTap | GestureTapCallback? | - | tab点击事件 |
+| popUpButtonConfig | TBottomTabBarPopUpBtnConfig? | - | 弹窗配置 |
+| selectedIcon | Widget? | - | 选中时图标 |
+| selectTabTextStyle | TextStyle? | - | 文本已选择样式 basicType为text时必填 |
+| tabText | String? | - | tab 文本 |
+| unselectedIcon | Widget? | - | 未选中时图标 |
+| unselectTabTextStyle | TextStyle? | - | 文本未选择样式 basicType为text时必填 |
 
 ```
 ```

--- a/tdesign-component/example/assets/api/tabs_api.md
+++ b/tdesign-component/example/assets/api/tabs_api.md
@@ -1,17 +1,4 @@
 ## API
-### TTabBarView
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| children | List<Widget> | - | 子widget列表 |
-| controller | TabController? | - | 控制器 |
-| isSlideSwitch | bool | false | 是否可以滑动切换 |
-| key |  | - |  |
-
-```
-```
-
 ### TTabBar
 #### 默认构造方法
 
@@ -65,3 +52,16 @@
 | size | TTabSize | TTabSize.small | 选项卡尺寸 |
 | text | String? | - | 文字内容 |
 | textMargin | EdgeInsetsGeometry? | - | 中间内容宽度 |
+
+```
+```
+
+### TTabBarView
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| children | List<Widget> | - | 子widget列表 |
+| controller | TabController? | - | 控制器 |
+| isSlideSwitch | bool | false | 是否可以滑动切换 |
+| key |  | - |  |

--- a/tdesign-component/example/assets/api/time-counter_api.md
+++ b/tdesign-component/example/assets/api/time-counter_api.md
@@ -1,4 +1,29 @@
 ## API
+### TTimeCounter
+#### 简介
+计时组件
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| autoStart | bool | true | 是否自动开始倒计时 |
+| content | dynamic | 'default' | 'default' / Widget Function(int time) / Widget |
+| controller | TTimeCounterController? | - | 控制器，可控制开始/暂停/继续/重置 |
+| direction | TTimeCounterDirection | TTimeCounterDirection.down | 计时方向，默认倒计时 |
+| format | String | 'HH:mm:ss' | 时间格式，DD-日，HH-时，mm-分，ss-秒，SSS-毫秒（分隔符必须为长度为1的非空格的字符） |
+| key |  | - |  |
+| millisecond | bool | false | 是否开启毫秒级渲染 |
+| onChange |  Function(int time)? | - | 时间变化时触发回调 |
+| onFinish | VoidCallback? | - | 计时结束时触发回调 |
+| size | TTimeCounterSize | TTimeCounterSize.medium | 尺寸 |
+| splitWithUnit | bool | false | 使用时间单位分割 |
+| style | TTimeCounterStyle? | - | 自定义样式，有则优先用它，没有则根据size和theme选取 |
+| theme | TTimeCounterTheme | TTimeCounterTheme.defaultTheme | 风格 |
+| time | int | - | 必需；计时时长，单位毫秒 |
+
+```
+```
+
 ### TTimeCounterController
 #### 简介
 倒计时组件控制器，可控制开始(`start()`)/暂停(`pause()`)/继续(`resume()`)/重置(`reset([int? time])`)
@@ -34,28 +59,3 @@
 | 名称  | 说明 |
 | --- |  --- |
 | TTimeCounterStyle.generateStyle  | 生成默认样式 |
-
-```
-```
-
-### TTimeCounter
-#### 简介
-计时组件
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| autoStart | bool | true | 是否自动开始倒计时 |
-| content | dynamic | 'default' | 'default' / Widget Function(int time) / Widget |
-| controller | TTimeCounterController? | - | 控制器，可控制开始/暂停/继续/重置 |
-| direction | TTimeCounterDirection | TTimeCounterDirection.down | 计时方向，默认倒计时 |
-| format | String | 'HH:mm:ss' | 时间格式，DD-日，HH-时，mm-分，ss-秒，SSS-毫秒（分隔符必须为长度为1的非空格的字符） |
-| key |  | - |  |
-| millisecond | bool | false | 是否开启毫秒级渲染 |
-| onChange |  Function(int time)? | - | 时间变化时触发回调 |
-| onFinish | VoidCallback? | - | 计时结束时触发回调 |
-| size | TTimeCounterSize | TTimeCounterSize.medium | 尺寸 |
-| splitWithUnit | bool | false | 使用时间单位分割 |
-| style | TTimeCounterStyle? | - | 自定义样式，有则优先用它，没有则根据size和theme选取 |
-| theme | TTimeCounterTheme | TTimeCounterTheme.defaultTheme | 风格 |
-| time | int | - | 必需；计时时长，单位毫秒 |

--- a/tdesign-component/example/assets/api/tree-select_api.md
+++ b/tdesign-component/example/assets/api/tree-select_api.md
@@ -1,19 +1,4 @@
 ## API
-### TSelectOption
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| children | List<TSelectOption> | const [] | 子选项 |
-| columnWidth | double? | - | 自定义宽度，允许用户指定每个选项的宽度 |
-| label | String | - | 标签 |
-| maxLines | int | 1 | 最大显示行数 |
-| multiple | bool | false | 当前子项支持多选 |
-| value | dynamic | - | 值 |
-
-```
-```
-
 ### TTreeSelect
 #### 默认构造方法
 
@@ -27,3 +12,18 @@
 | options | List<TSelectOption> | const [] | 展示的选项列表 |
 | outwardCornerRadius | double | 9 | 一级菜单选中项的外弯折圆角半径，默认为 9 |
 | style | TTreeSelectStyle | TTreeSelectStyle.normal | 一级菜单样式 |
+
+```
+```
+
+### TSelectOption
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| children | List<TSelectOption> | const [] | 子选项 |
+| columnWidth | double? | - | 自定义宽度，允许用户指定每个选项的宽度 |
+| label | String | - | 标签 |
+| maxLines | int | 1 | 最大显示行数 |
+| multiple | bool | false | 当前子项支持多选 |
+| value | dynamic | - | 值 |

--- a/tdesign-component/example/assets/code/input._specialTypeLoginForm.txt
+++ b/tdesign-component/example/assets/code/input._specialTypeLoginForm.txt
@@ -1,0 +1,35 @@
+
+  Widget _specialTypeLoginForm(BuildContext context) {
+    // 登录场景：上下两个密码框，演示 issue #763 的修复效果。
+    // - 点击任一密码框：键盘应立即弹出（无需点两次）
+    // - 在两个密码框间切换焦点：键盘保持显示，不会被默认 onTapOutside 收起
+    // - 借助 AutofillGroup + AutofillHints.password 触发系统密码自动填充
+    return AutofillGroup(
+      child: Column(
+        children: [
+          TInput(
+            type: TInputType.normal,
+            controller: controller[28],
+            obscureText: true,
+            leftLabel: '密码',
+            hintText: '请输入密码',
+            autofillHints: const [AutofillHints.password],
+            inputAction: TextInputAction.next,
+            needClear: false,
+          ),
+          const SizedBox(height: 8),
+          TInput(
+            type: TInputType.normal,
+            controller: controller[29],
+            obscureText: true,
+            leftLabel: '确认密码',
+            hintText: '请再次输入密码',
+            autofillHints: const [AutofillHints.password],
+            inputAction: TextInputAction.done,
+            needClear: false,
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }

--- a/tdesign-component/example/lib/page/t_input_page.dart
+++ b/tdesign-component/example/lib/page/t_input_page.dart
@@ -86,6 +86,9 @@ class _TInputViewPageState extends State<TInputViewPage> {
               ExampleItem(desc: '自适应高度输入框', builder: _autoHeightInput),
               ExampleItem(builder: _specialTypeNumber),
               ExampleItem(builder: _specialTypePasswordWithPaste),
+              ExampleItem(
+                  desc: '登录场景：双密码框焦点切换不收键盘',
+                  builder: _specialTypeLoginForm),
               ExampleItem(builder: (context) {
                 return Container();
               }),
@@ -494,6 +497,42 @@ class _TInputViewPageState extends State<TInputViewPage> {
           height: 16,
         ),
       ],
+    );
+  }
+
+  @Demo(group: 'input')
+  Widget _specialTypeLoginForm(BuildContext context) {
+    // 登录场景：上下两个密码框，演示 issue #763 的修复效果。
+    // - 点击任一密码框：键盘应立即弹出（无需点两次）
+    // - 在两个密码框间切换焦点：键盘保持显示，不会被默认 onTapOutside 收起
+    // - 借助 AutofillGroup + AutofillHints.password 触发系统密码自动填充
+    return AutofillGroup(
+      child: Column(
+        children: [
+          TInput(
+            type: TInputType.normal,
+            controller: controller[28],
+            obscureText: true,
+            leftLabel: '密码',
+            hintText: '请输入密码',
+            autofillHints: const [AutofillHints.password],
+            inputAction: TextInputAction.next,
+            needClear: false,
+          ),
+          const SizedBox(height: 8),
+          TInput(
+            type: TInputType.normal,
+            controller: controller[29],
+            obscureText: true,
+            leftLabel: '确认密码',
+            hintText: '请再次输入密码',
+            autofillHints: const [AutofillHints.password],
+            inputAction: TextInputAction.done,
+            needClear: false,
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
     );
   }
 

--- a/tdesign-component/lib/src/components/input/input_view.dart
+++ b/tdesign-component/lib/src/components/input/input_view.dart
@@ -82,6 +82,11 @@ class TInputView extends StatelessWidget {
   /// 是否启用交互式选择
   final bool? enableInteractiveSelection;
 
+  /// 自动填充提示，传递给 TextField 的 autofillHints
+  /// 例如密码输入框传 [AutofillHints.password]，可让系统/输入法识别为密码字段
+  /// 配合 AutofillGroup 使用可触发系统自动填充
+  final Iterable<String>? autofillHints;
+
   const TInputView(
       {Key? key,
       required this.textStyle,
@@ -110,10 +115,26 @@ class TInputView extends StatelessWidget {
       this.onTapOutside,
       this.selectionControls,
       this.contextMenuBuilder,
-      this.enableInteractiveSelection})
+      this.enableInteractiveSelection,
+      this.autofillHints})
       : super(
           key: key,
         );
+
+  /// 默认的 onTapOutside 实现：不主动 unfocus 当前输入框。
+  ///
+  /// Flutter 3.13+ 的 EditableText 默认 onTapOutside 会在指针落到输入框外部
+  /// 任意位置时调用 focusNode.unfocus()，导致以下交互问题（见 issue #763）：
+  /// 1. Android 上从一个 TInput 点击切换到另一个 TInput 时，前者的
+  ///    onTapOutside 会先 unfocus，与后者的 requestFocus 在同一帧竞争，
+  ///    最终表现为键盘被收起；
+  /// 2. 在 Stack/Row 等复杂布局中，第一次 tap 触发 outside 判定，造成
+  ///    "点一次只获焦不弹键盘"的现象。
+  ///
+  /// 本组件采用更克制的策略：tap outside 时不主动 unfocus，让 framework
+  /// 根据真正的焦点变更来管理键盘显隐。业务方如需"点空白处收起键盘"，
+  /// 可显式传入 onTapOutside 覆盖此默认值。
+  static void _defaultOnTapOutside(PointerDownEvent event) {}
 
   @override
   Widget build(BuildContext context) {
@@ -134,7 +155,8 @@ class TInputView extends StatelessWidget {
       maxLines: maxLines,
       minLines: minLines,
       maxLength: maxLength,
-      onTapOutside: onTapOutside,
+      onTapOutside: onTapOutside ?? _defaultOnTapOutside,
+      autofillHints: autofillHints,
       selectionControls: selectionControls,
       contextMenuBuilder: contextMenuBuilder,
       style: textStyle,

--- a/tdesign-component/lib/src/components/input/t_input.dart
+++ b/tdesign-component/lib/src/components/input/t_input.dart
@@ -74,6 +74,8 @@ class TInput extends StatelessWidget {
     this.selectionControls,
     this.contextMenuBuilder,
     this.enableInteractiveSelection,
+    this.autofillHints,
+    this.onLabelTap,
   }) : spacer = spacer ?? TInputSpacer.generateDefault();
 
   /// 输入框宽度(TCardStyle时必须设置该参数)
@@ -235,6 +237,18 @@ class TInput extends StatelessWidget {
   /// 是否启用交互式选择
   final bool? enableInteractiveSelection;
 
+  /// 自动填充提示，例如密码框可传 `[AutofillHints.password]`，让系统/输入法
+  /// 识别为密码字段，配合 [AutofillGroup] 触发自动填充。
+  final Iterable<String>? autofillHints;
+
+  /// 点击左侧 leftIcon / leftLabel 区域时的回调。
+  ///
+  /// 默认值为 null，此时点击 label 区域会通过 [HitTestBehavior.translucent]
+  /// 穿透到下方输入框，使输入框获得焦点并弹出键盘（这是密码输入框场景下
+  /// 的常见预期）。若业务方需要拦截 label 点击事件（例如点 label 弹出帮助
+  /// 提示），可传入此回调。
+  final GestureTapCallback? onLabelTap;
+
   /// 获取输入框规格
   double getInputPadding() {
     switch (size) {
@@ -346,6 +360,12 @@ class TInput extends StatelessWidget {
               SizedBox(
                 width: leftLabelWidth,
                 child: GestureDetector(
+                  // [issue #763] 加上 translucent 命中测试行为：当 onLabelTap
+                  // 未传时，让点击事件穿透到下方 TextField，避免 Android 上
+                  // 第一次 tap 只获焦不弹键盘的问题；同时显式传 onTap 让
+                  // GestureDetector 的命中行为可预期。
+                  behavior: HitTestBehavior.translucent,
+                  onTap: onLabelTap,
                   child: Row(
                     children: [
                       Visibility(
@@ -440,6 +460,7 @@ class TInput extends StatelessWidget {
                       selectionControls: selectionControls,
                       contextMenuBuilder: contextMenuBuilder,
                       enableInteractiveSelection: enableInteractiveSelection,
+                      autofillHints: autofillHints,
                     ),
                     Visibility(
                       child: Container(
@@ -675,6 +696,7 @@ class TInput extends StatelessWidget {
                         selectionControls: selectionControls,
                         contextMenuBuilder: contextMenuBuilder,
                         enableInteractiveSelection: enableInteractiveSelection,
+                        autofillHints: autofillHints,
                       ),
                     ),
                     Visibility(
@@ -796,6 +818,7 @@ class TInput extends StatelessWidget {
               selectionControls: selectionControls,
               contextMenuBuilder: contextMenuBuilder,
               enableInteractiveSelection: enableInteractiveSelection,
+              autofillHints: autofillHints,
             ),
           ),
           Container(
@@ -890,6 +913,7 @@ class TInput extends StatelessWidget {
                     selectionControls: selectionControls,
                     contextMenuBuilder: contextMenuBuilder,
                     enableInteractiveSelection: enableInteractiveSelection,
+                    autofillHints: autofillHints,
                   ),
                 ),
               ),

--- a/tdesign-component/test/input/t_input_test.dart
+++ b/tdesign-component/test/input/t_input_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tdesign_flutter/tdesign_flutter.dart';
+
+/// TInput 密码输入框相关 Widget 测试
+///
+/// 覆盖 [issue #763](https://github.com/Tencent/tdesign-flutter/issues/763)
+/// 的修复点：
+/// 1. `obscureText: true` 正确透传到底层 TextField；
+/// 2. `autofillHints` 正确透传到底层 TextField；
+/// 3. label 区域 GestureDetector 使用 `HitTestBehavior.translucent`，
+///    确保点击事件不抢夺，不影响输入框获取焦点；
+/// 4. 默认 `onTapOutside` 不会主动 unfocus，从而保证多个 TInput 之间
+///    切换焦点时键盘不会被错误收起。
+void main() {
+  group('TInput obscureText (issue #763)', () {
+    testWidgets('obscureText: true 应正确透传到底层 TextField',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TInput(
+              obscureText: true,
+              leftLabel: '密码',
+              hintText: '请输入密码',
+              needClear: false,
+            ),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.obscureText, isTrue,
+          reason: 'TInput.obscureText 必须透传到底层 TextField');
+    });
+
+    testWidgets('autofillHints 应正确透传到底层 TextField',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AutofillGroup(
+              child: TInput(
+                obscureText: true,
+                leftLabel: '密码',
+                autofillHints: const [AutofillHints.password],
+                needClear: false,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.autofillHints, equals(const [AutofillHints.password]),
+          reason: 'TInput.autofillHints 必须透传到底层 TextField');
+    });
+
+    testWidgets('label 区域 GestureDetector 应使用 translucent 命中行为',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TInput(
+              obscureText: true,
+              leftLabel: '密码',
+              hintText: '请输入密码',
+              needClear: false,
+            ),
+          ),
+        ),
+      );
+
+      // 在 label 区域至少存在一个 behavior == translucent 的 GestureDetector，
+      // 确保点击 label 区不会抢夺手势导致首次 tap 不弹键盘。
+      final detectors =
+          tester.widgetList<GestureDetector>(find.byType(GestureDetector));
+      final hasTranslucent = detectors
+          .any((d) => d.behavior == HitTestBehavior.translucent);
+      expect(hasTranslucent, isTrue,
+          reason: 'label 区域 GestureDetector 必须使用 HitTestBehavior.translucent，'
+              '避免抢夺 TextField 的点击手势导致首次 tap 不弹键盘');
+    });
+
+    testWidgets('未传 onTapOutside 时，TextField 应使用安全默认值（不主动 unfocus）',
+        (WidgetTester tester) async {
+      final focusA = FocusNode();
+      final focusB = FocusNode();
+      addTearDown(focusA.dispose);
+      addTearDown(focusB.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                TInput(
+                  key: const Key('input-a'),
+                  obscureText: true,
+                  leftLabel: '密码A',
+                  focusNode: focusA,
+                  needClear: false,
+                ),
+                TInput(
+                  key: const Key('input-b'),
+                  obscureText: true,
+                  leftLabel: '密码B',
+                  focusNode: focusB,
+                  needClear: false,
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // 模拟用户点击第一个输入框获取焦点
+      focusA.requestFocus();
+      await tester.pump();
+      expect(focusA.hasFocus, isTrue);
+
+      // 模拟用户切换到第二个输入框
+      focusB.requestFocus();
+      await tester.pump();
+
+      // 关键断言：两个 TextField 的 onTapOutside 都不是 null（即使用了
+      // TInputView 的安全默认值），保证多个 TInput 切换焦点时键盘行为正确。
+      final textFields =
+          tester.widgetList<TextField>(find.byType(TextField)).toList();
+      expect(textFields.length, 2);
+      for (final tf in textFields) {
+        expect(tf.onTapOutside, isNotNull,
+            reason: 'TInputView 必须为 onTapOutside 提供不主动 unfocus 的安全默认值，'
+                '避免多个 TInput 切换焦点时键盘被错误收起');
+      }
+    });
+
+    testWidgets('显式传入 onTapOutside 时应使用业务方提供的回调',
+        (WidgetTester tester) async {
+      var customCalled = false;
+      void customOnTapOutside(PointerDownEvent event) {
+        customCalled = true;
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TInput(
+              obscureText: true,
+              leftLabel: '密码',
+              onTapOutside: customOnTapOutside,
+              needClear: false,
+            ),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      // 直接调用底层 TextField 的回调，验证业务方传入的 onTapOutside 被采用
+      textField.onTapOutside!(const PointerDownEvent());
+      expect(customCalled, isTrue,
+          reason: '业务方显式传入的 onTapOutside 必须覆盖默认值');
+    });
+
+    testWidgets('onLabelTap 默认 null 时点击 label 区域不抛错',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TInput(
+              obscureText: true,
+              leftLabel: '密码',
+              needClear: false,
+            ),
+          ),
+        ),
+      );
+
+      // 找到带 leftLabel 文案的 TText 并点击
+      await tester.tap(find.text('密码'), warnIfMissed: false);
+      await tester.pump();
+      // 不抛错即通过；命中行为由 translucent 保证可穿透到 TextField
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('显式传入 onLabelTap 时点击 label 区域应触发回调',
+        (WidgetTester tester) async {
+      var labelTapped = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TInput(
+              obscureText: true,
+              leftLabel: '密码',
+              onLabelTap: () {
+                labelTapped = true;
+              },
+              needClear: false,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('密码'), warnIfMissed: false);
+      await tester.pump();
+      expect(labelTapped, isTrue,
+          reason: 'TInput.onLabelTap 必须在点击 label 区域时被触发');
+    });
+  });
+}

--- a/tdesign-site/src/action-sheet/README.md
+++ b/tdesign-site/src/action-sheet/README.md
@@ -887,6 +887,25 @@ Widget _buildIconListLeftActionSheet(BuildContext context) {
 
 
 ## API
+### TActionSheetItem
+#### 简介
+动作面板项目
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| badge | TBadge? | - | 角标 |
+| description | String? | - | 描述信息 |
+| disabled | bool | false | 是否禁用 |
+| group | String? | - | 分组，用于带描述多行滚动宫格 |
+| icon | Widget? | - | 图标 |
+| iconSize | double? | - | 图标大小 |
+| label | String | - | 标题 |
+| textStyle | TextStyle? | - | 标题样式 |
+
+```
+```
+
 ### TActionSheet
 #### 简介
 动作面板
@@ -923,25 +942,6 @@ Widget _buildIconListLeftActionSheet(BuildContext context) {
 | showGridActionSheet |  |   required BuildContext context,  required List<TActionSheetItem> items,  TActionSheetAlign align,  String? cancelText,  bool showCancel,  TActionSheetItemCallback? onSelected,  bool showOverlay,  bool closeOnOverlayClick,  int count,  int rows,  double itemHeight,  double itemMinWidth,  bool scrollable,  bool showPagination,  VoidCallback? onCancel,  String? description,  VoidCallback? onClose,  bool useSafeArea, | 显示宫格类型面板 |
 | showGroupActionSheet |  |   required BuildContext context,  required List<TActionSheetItem> items,  TActionSheetAlign align,  String? cancelText,  bool showCancel,  TActionSheetItemCallback? onSelected,  bool showOverlay,  bool closeOnOverlayClick,  double itemHeight,  double itemMinWidth,  VoidCallback? onCancel,  VoidCallback? onClose,  bool useSafeArea, | 显示分组类型面板 |
 | showListActionSheet |  |   required BuildContext context,  required List<TActionSheetItem> items,  TActionSheetAlign align,  String? cancelText,  bool showCancel,  VoidCallback? onCancel,  TActionSheetItemCallback? onSelected,  bool showOverlay,  bool closeOnOverlayClick,  VoidCallback? onClose,  bool useSafeArea, | 显示列表类型面板 |
-
-```
-```
-
-### TActionSheetItem
-#### 简介
-动作面板项目
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| badge | TBadge? | - | 角标 |
-| description | String? | - | 描述信息 |
-| disabled | bool | false | 是否禁用 |
-| group | String? | - | 分组，用于带描述多行滚动宫格 |
-| icon | Widget? | - | 图标 |
-| iconSize | double? | - | 图标大小 |
-| label | String | - | 标题 |
-| textStyle | TextStyle? | - | 标题样式 |
 
 
   

--- a/tdesign-site/src/button/README.md
+++ b/tdesign-site/src/button/README.md
@@ -738,31 +738,6 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 
 ## API
-### TButtonStyle
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| backgroundColor | Color? | - | 背景颜色 |
-| frameColor | Color? | - | 边框颜色 |
-| frameWidth | double? | - | 边框宽度 |
-| gradient | Gradient? | - | 渐变背景色 |
-| radius | BorderRadiusGeometry? | - | 自定义圆角 |
-| textColor | Color? | - | 文字颜色 |
-
-
-#### 工厂构造方法
-
-| 名称  | 说明 |
-| --- |  --- |
-| TButtonStyle.generateFillStyleByTheme  | 生成不同主题的填充按钮样式 |
-| TButtonStyle.generateGhostStyleByTheme  | 生成不同主题的幽灵按钮样式 |
-| TButtonStyle.generateOutlineStyleByTheme  | 生成不同主题的描边按钮样式 |
-| TButtonStyle.generateTextStyleByTheme  | 生成不同主题的文本按钮样式 |
-
-```
-```
-
 ### TButton
 #### 默认构造方法
 
@@ -793,6 +768,31 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | theme | TButtonTheme? | - | 主题 |
 | type | TButtonType | TButtonType.fill | 类型：填充，描边，文字 |
 | width | double? | - | 自定义宽度 |
+
+```
+```
+
+### TButtonStyle
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| backgroundColor | Color? | - | 背景颜色 |
+| frameColor | Color? | - | 边框颜色 |
+| frameWidth | double? | - | 边框宽度 |
+| gradient | Gradient? | - | 渐变背景色 |
+| radius | BorderRadiusGeometry? | - | 自定义圆角 |
+| textColor | Color? | - | 文字颜色 |
+
+
+#### 工厂构造方法
+
+| 名称  | 说明 |
+| --- |  --- |
+| TButtonStyle.generateFillStyleByTheme  | 生成不同主题的填充按钮样式 |
+| TButtonStyle.generateGhostStyleByTheme  | 生成不同主题的幽灵按钮样式 |
+| TButtonStyle.generateOutlineStyleByTheme  | 生成不同主题的描边按钮样式 |
+| TButtonStyle.generateTextStyleByTheme  | 生成不同主题的文本按钮样式 |
 
 
   

--- a/tdesign-site/src/calendar/README.md
+++ b/tdesign-site/src/calendar/README.md
@@ -1445,34 +1445,6 @@ Widget _buildLunar(BuildContext context) {
 
 
 ## API
-### TCalendarStyle
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| cellDecoration | BoxDecoration? | - | 日期decoration |
-| cellPrefixStyle | TextStyle? | - | 日期前面的字符串的样式 |
-| cellStyle | TextStyle? | - | 日期样式 |
-| cellSuffixStyle | TextStyle? | - | 日期后面的字符串的样式 |
-| centreColor | Color? | - | 日期范围内背景样式 |
-| decoration |  | - |  |
-| monthTitleStyle | TextStyle? | - | body区域 年月文字样式 |
-| titleCloseColor | Color? | - | header区域 关闭图标的颜色 |
-| titleMaxLine | int? | - | header区域 [TCalendar.title]的行数 |
-| titleStyle | TextStyle? | - | header区域 [TCalendar.title]的样式 |
-| weekdayStyle | TextStyle? | - | header区域 周 文字样式 |
-
-
-#### 工厂构造方法
-
-| 名称  | 说明 |
-| --- |  --- |
-| TCalendarStyle.cellStyle  | 日期样式 |
-| TCalendarStyle.generateStyle  | 生成默认样式 |
-
-```
-```
-
 ### TCalendar
 #### 默认构造方法
 
@@ -1515,10 +1487,6 @@ Widget _buildLunar(BuildContext context) {
 ```
 ```
 
-### TCalendarDataSource
-```
-```
-
 ### TCalendarPopup
 #### 默认构造方法
 
@@ -1534,6 +1502,38 @@ Widget _buildLunar(BuildContext context) {
 | top | double? | - | 距离顶部的距离 |
 | visible | bool? | - | 默认是否显示日历 |
 
+```
+```
+
+### TCalendarStyle
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| cellDecoration | BoxDecoration? | - | 日期decoration |
+| cellPrefixStyle | TextStyle? | - | 日期前面的字符串的样式 |
+| cellStyle | TextStyle? | - | 日期样式 |
+| cellSuffixStyle | TextStyle? | - | 日期后面的字符串的样式 |
+| centreColor | Color? | - | 日期范围内背景样式 |
+| decoration |  | - |  |
+| monthTitleStyle | TextStyle? | - | body区域 年月文字样式 |
+| titleCloseColor | Color? | - | header区域 关闭图标的颜色 |
+| titleMaxLine | int? | - | header区域 [TCalendar.title]的行数 |
+| titleStyle | TextStyle? | - | header区域 [TCalendar.title]的样式 |
+| weekdayStyle | TextStyle? | - | header区域 周 文字样式 |
+
+
+#### 工厂构造方法
+
+| 名称  | 说明 |
+| --- |  --- |
+| TCalendarStyle.cellStyle  | 日期样式 |
+| TCalendarStyle.generateStyle  | 生成默认样式 |
+
+```
+```
+
+### TCalendarDataSource
 ```
 ```
 

--- a/tdesign-site/src/cell/README.md
+++ b/tdesign-site/src/cell/README.md
@@ -158,6 +158,45 @@ Widget _buildCard(BuildContext context) {
 
 
 ## API
+### TCell
+#### 简介
+单元格组件
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| align | TCellAlign? | TCellAlign.middle | 内容的对齐方式，默认居中对齐。可选项：top/middle/bottom |
+| arrow | bool? | false | 是否显示右侧箭头 |
+| bordered | bool? | true | 是否显示下边框，仅在TCellGroup组件下起作用 |
+| description | String? | - | 下方内容描述文字 |
+| descriptionWidget | Widget? | - | 下方内容描述组件 |
+| disabled | bool? | false | 禁用 |
+| height | double? | - | 高度 |
+| hover | bool? | true | 是否开启点击反馈 |
+| image | ImageProvider? | - | 主图 |
+| imageCircle | double? | 50 | 主图圆角，默认50（圆形） |
+| imageSize | double? | - | 主图尺寸 |
+| imageWidget | Widget? | - | 主图组件 |
+| key |  | - |  |
+| leftIcon | IconData? | - | 左侧图标，出现在单元格标题的左侧 |
+| leftIconWidget | Widget? | - | 左侧图标组件 |
+| note | String? | - | 和标题同行的说明文字 |
+| noteMaxLine | int | 1 | 说明文字组件 最大行数 |
+| noteMaxWidth | double? | - | 说明文字组件 最大宽度，超过部分显示省略号，防止文字溢出 |
+| noteWidget | Widget? | - | 说明文字组件 |
+| onClick | TCellClick? | - | 点击事件 |
+| onLongPress | TCellClick? | - | 长按事件 |
+| required | bool? | false | 是否显示表单必填星号 |
+| rightIcon | IconData? | - | 最右侧图标 |
+| rightIconWidget | Widget? | - | 最右侧图标组件 |
+| showBottomBorder | bool? | false | 是否显示下边框（建议TCellGroup组件下false，避免与bordered重叠） |
+| style | TCellStyle? | - | 自定义样式 |
+| title | String? | - | 标题 |
+| titleWidget | Widget? | - | 标题组件 |
+
+```
+```
+
 ### TCellGroup
 #### 简介
 单元格组组件
@@ -211,45 +250,6 @@ Widget _buildCard(BuildContext context) {
 | 名称  | 说明 |
 | --- |  --- |
 | TCellStyle.cellStyle  | 生成单元格默认样式 |
-
-```
-```
-
-### TCell
-#### 简介
-单元格组件
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| align | TCellAlign? | TCellAlign.middle | 内容的对齐方式，默认居中对齐。可选项：top/middle/bottom |
-| arrow | bool? | false | 是否显示右侧箭头 |
-| bordered | bool? | true | 是否显示下边框，仅在TCellGroup组件下起作用 |
-| description | String? | - | 下方内容描述文字 |
-| descriptionWidget | Widget? | - | 下方内容描述组件 |
-| disabled | bool? | false | 禁用 |
-| height | double? | - | 高度 |
-| hover | bool? | true | 是否开启点击反馈 |
-| image | ImageProvider? | - | 主图 |
-| imageCircle | double? | 50 | 主图圆角，默认50（圆形） |
-| imageSize | double? | - | 主图尺寸 |
-| imageWidget | Widget? | - | 主图组件 |
-| key |  | - |  |
-| leftIcon | IconData? | - | 左侧图标，出现在单元格标题的左侧 |
-| leftIconWidget | Widget? | - | 左侧图标组件 |
-| note | String? | - | 和标题同行的说明文字 |
-| noteMaxLine | int | 1 | 说明文字组件 最大行数 |
-| noteMaxWidth | double? | - | 说明文字组件 最大宽度，超过部分显示省略号，防止文字溢出 |
-| noteWidget | Widget? | - | 说明文字组件 |
-| onClick | TCellClick? | - | 点击事件 |
-| onLongPress | TCellClick? | - | 长按事件 |
-| required | bool? | false | 是否显示表单必填星号 |
-| rightIcon | IconData? | - | 最右侧图标 |
-| rightIconWidget | Widget? | - | 最右侧图标组件 |
-| showBottomBorder | bool? | false | 是否显示下边框（建议TCellGroup组件下false，避免与bordered重叠） |
-| style | TCellStyle? | - | 自定义样式 |
-| title | String? | - | 标题 |
-| titleWidget | Widget? | - | 标题组件 |
 
 
   

--- a/tdesign-site/src/checkbox/README.md
+++ b/tdesign-site/src/checkbox/README.md
@@ -426,28 +426,6 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 
 ## API
-### TCheckboxGroup
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| checkedIds | List<String>? | - | 勾选的CheckBox id列表 |
-| child |  | - |  |
-| contentDirection | TContentDirection? | - | 文字相对icon的方位 |
-| controller | TCheckboxGroupController? | - | 可以通过控制器操作勾选状态 |
-| customContentBuilder | ContentBuilder? | - | CheckBox完全自定义内容 |
-| customIconBuilder | IconBuilder? | - | 自定义选择icon的样式 |
-| key |  | - |  |
-| maxChecked | int? | - | 最多可以勾选多少 |
-| onChangeGroup | OnGroupChange? | - | 状态变化监听器 |
-| onOverloadChecked | VoidCallback? | - | 超过最大可勾选的个数 |
-| spacing | double? | - | CheckBoxicon和文字的距离 |
-| style | TCheckboxStyle? | - | CheckBox复选框样式：圆形或方形 |
-| titleMaxLine | int? | - | CheckBox标题的行数 |
-
-```
-```
-
 ### TCheckbox
 #### 默认构造方法
 
@@ -480,6 +458,28 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | titleColor | Color? | - | 标题文字颜色 |
 | titleFont | Font? | - | 标题字体大小 |
 | titleMaxLine | int? | - | 标题的行数 |
+
+```
+```
+
+### TCheckboxGroup
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| checkedIds | List<String>? | - | 勾选的CheckBox id列表 |
+| child |  | - |  |
+| contentDirection | TContentDirection? | - | 文字相对icon的方位 |
+| controller | TCheckboxGroupController? | - | 可以通过控制器操作勾选状态 |
+| customContentBuilder | ContentBuilder? | - | CheckBox完全自定义内容 |
+| customIconBuilder | IconBuilder? | - | 自定义选择icon的样式 |
+| key |  | - |  |
+| maxChecked | int? | - | 最多可以勾选多少 |
+| onChangeGroup | OnGroupChange? | - | 状态变化监听器 |
+| onOverloadChecked | VoidCallback? | - | 超过最大可勾选的个数 |
+| spacing | double? | - | CheckBoxicon和文字的距离 |
+| style | TCheckboxStyle? | - | CheckBox复选框样式：圆形或方形 |
+| titleMaxLine | int? | - | CheckBox标题的行数 |
 
 
   

--- a/tdesign-site/src/dialog/README.md
+++ b/tdesign-site/src/dialog/README.md
@@ -703,27 +703,38 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 
 ## API
-### TImageDialog
+### TAlertDialog
 #### 默认构造方法
 
 | 参数 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
 | backgroundColor | Color? | - | 背景颜色 |
+| buttonStyle |  | TDialogButtonStyle.normal |  |
 | buttonWidget | Widget? | - | 自定义按钮 |
 | content | String? | - | 内容 |
 | contentColor | Color? | - | 内容颜色 |
+| contentMaxHeight | double | 0 | 内容的最大高度，默认为0，也就是不限制高度 |
 | contentWidget | Widget? | - | 内容Widget |
-| image | Image | - | 图片 |
-| imagePosition | TDialogImagePosition? | TDialogImagePosition.top | 图片位置 |
 | key |  | - |  |
 | leftBtn | TDialogButtonOptions? | - | 左侧按钮配置 |
-| padding | EdgeInsets? | - | 内容内边距 |
+| leftBtnAction |  Function()? | - | 左侧按钮默认点击 |
+| padding | EdgeInsets? | const EdgeInsets.fromLTRB(24, 32, 24, 0) | 内容内边距 |
 | radius | double | 12.0 | 圆角 |
 | rightBtn | TDialogButtonOptions? | - | 右侧按钮配置 |
+| rightBtnAction |  Function()? | - | 右侧按钮默认点击 |
 | showCloseButton | bool? | - | 显示右上角关闭按钮 |
 | title | String? | - | 标题 |
 | titleAlignment | AlignmentGeometry? | - | 标题对齐模式 |
 | titleColor | Color? | - | 标题颜色 |
+
+
+#### 工厂构造方法
+
+| 名称  | 说明 |
+| --- |  --- |
+| TAlertDialog.vertical  | 纵向按钮排列的对话框
+
+ [buttons]参数是必须的，纵向按钮默认样式都是[TButtonTheme.primary] |
 
 ```
 ```
@@ -752,6 +763,24 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | titleAlignment | AlignmentGeometry? | - | 标题对齐模式 |
 | titleColor | Color? | - | 标题颜色 |
 | width |  | - |  |
+
+```
+```
+
+### TDialogButtonOptions
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| action |  Function()? | - | 点击操作 |
+| fontWeight | FontWeight? | - | 字体粗细 |
+| height | double? | - | 按钮高度 |
+| style | TButtonStyle? | - | 按钮样式 |
+| theme | TButtonTheme? | - | 按钮类型 |
+| title | String | - | 标题内容 |
+| titleColor | Color? | - | 标题颜色 |
+| titleSize | double? | - | 字体大小 |
+| type | TButtonType? | - | 按钮类型 |
 
 ```
 ```
@@ -858,56 +887,27 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 ```
 ```
 
-### TDialogButtonOptions
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| action |  Function()? | - | 点击操作 |
-| fontWeight | FontWeight? | - | 字体粗细 |
-| height | double? | - | 按钮高度 |
-| style | TButtonStyle? | - | 按钮样式 |
-| theme | TButtonTheme? | - | 按钮类型 |
-| title | String | - | 标题内容 |
-| titleColor | Color? | - | 标题颜色 |
-| titleSize | double? | - | 字体大小 |
-| type | TButtonType? | - | 按钮类型 |
-
-```
-```
-
-### TAlertDialog
+### TImageDialog
 #### 默认构造方法
 
 | 参数 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
 | backgroundColor | Color? | - | 背景颜色 |
-| buttonStyle |  | TDialogButtonStyle.normal |  |
 | buttonWidget | Widget? | - | 自定义按钮 |
 | content | String? | - | 内容 |
 | contentColor | Color? | - | 内容颜色 |
-| contentMaxHeight | double | 0 | 内容的最大高度，默认为0，也就是不限制高度 |
 | contentWidget | Widget? | - | 内容Widget |
+| image | Image | - | 图片 |
+| imagePosition | TDialogImagePosition? | TDialogImagePosition.top | 图片位置 |
 | key |  | - |  |
 | leftBtn | TDialogButtonOptions? | - | 左侧按钮配置 |
-| leftBtnAction |  Function()? | - | 左侧按钮默认点击 |
-| padding | EdgeInsets? | const EdgeInsets.fromLTRB(24, 32, 24, 0) | 内容内边距 |
+| padding | EdgeInsets? | - | 内容内边距 |
 | radius | double | 12.0 | 圆角 |
 | rightBtn | TDialogButtonOptions? | - | 右侧按钮配置 |
-| rightBtnAction |  Function()? | - | 右侧按钮默认点击 |
 | showCloseButton | bool? | - | 显示右上角关闭按钮 |
 | title | String? | - | 标题 |
 | titleAlignment | AlignmentGeometry? | - | 标题对齐模式 |
 | titleColor | Color? | - | 标题颜色 |
-
-
-#### 工厂构造方法
-
-| 名称  | 说明 |
-| --- |  --- |
-| TAlertDialog.vertical  | 纵向按钮排列的对话框
-
- [buttons]参数是必须的，纵向按钮默认样式都是[TButtonTheme.primary] |
 
 ```
 ```

--- a/tdesign-site/src/drawer/README.md
+++ b/tdesign-site/src/drawer/README.md
@@ -285,6 +285,36 @@ Widget _buildBottomSimple(BuildContext context) {
 
 
 ## API
+### TDrawer
+#### 简介
+抽屉组件
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| backgroundColor | Color? | - | 组件背景颜色 |
+| bordered | bool? | true | 是否显示边框 |
+| closeOnOverlayClick | bool? | true | 点击蒙层时是否关闭抽屉 |
+| contentWidget | Widget? | - | 自定义内容，优先级高于[items]/[footer]/[title] |
+| context | BuildContext | context | 上下文 |
+| drawerTop | double? | - | 距离顶部的距离 |
+| footer | Widget? | - | 抽屉的底部 |
+| hover | bool? | true | 是否开启点击反馈 |
+| isShowLastBordered | bool? | true | 是否显示最后一行分割线 |
+| items | List<TDrawerItem>? | - | 抽屉里的列表项 |
+| onClose | VoidCallback? | - | 关闭时触发 |
+| onItemClick | TDrawerItemClickCallback? | - | 点击抽屉里的列表项触发 |
+| placement | TDrawerPlacement? | TDrawerPlacement.right | 抽屉方向 |
+| showOverlay | bool? | true | 是否显示遮罩层 |
+| style | TCellStyle? | - | 列表自定义样式 |
+| title | String? | - | 抽屉的标题 |
+| titleWidget | Widget? | - | 抽屉的标题组件 |
+| visible | bool? | - | 组件是否可见 |
+| width | double? | 280 | 宽度 |
+
+```
+```
+
 ### TDrawerWidget
 #### 简介
 抽屉内容组件
@@ -320,36 +350,6 @@ Widget _buildBottomSimple(BuildContext context) {
 | content | Widget? | - | 完全自定义 |
 | icon | Widget? | - | 每列图标 |
 | title | String? | - | 每列标题 |
-
-```
-```
-
-### TDrawer
-#### 简介
-抽屉组件
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| backgroundColor | Color? | - | 组件背景颜色 |
-| bordered | bool? | true | 是否显示边框 |
-| closeOnOverlayClick | bool? | true | 点击蒙层时是否关闭抽屉 |
-| contentWidget | Widget? | - | 自定义内容，优先级高于[items]/[footer]/[title] |
-| context | BuildContext | context | 上下文 |
-| drawerTop | double? | - | 距离顶部的距离 |
-| footer | Widget? | - | 抽屉的底部 |
-| hover | bool? | true | 是否开启点击反馈 |
-| isShowLastBordered | bool? | true | 是否显示最后一行分割线 |
-| items | List<TDrawerItem>? | - | 抽屉里的列表项 |
-| onClose | VoidCallback? | - | 关闭时触发 |
-| onItemClick | TDrawerItemClickCallback? | - | 点击抽屉里的列表项触发 |
-| placement | TDrawerPlacement? | TDrawerPlacement.right | 抽屉方向 |
-| showOverlay | bool? | true | 是否显示遮罩层 |
-| style | TCellStyle? | - | 列表自定义样式 |
-| title | String? | - | 抽屉的标题 |
-| titleWidget | Widget? | - | 抽屉的标题组件 |
-| visible | bool? | - | 组件是否可见 |
-| width | double? | 280 | 宽度 |
 
 
   

--- a/tdesign-site/src/dropdown-menu/README.md
+++ b/tdesign-site/src/dropdown-menu/README.md
@@ -266,9 +266,31 @@ TDropdownMenu _buildGroup(BuildContext context) {
 
 
 ## API
-### TDropdownItemController
+### TDropdownMenu
 #### 简介
-下拉菜单控制器
+下拉菜单
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| arrowColor | Color? | - | 自定义箭头颜色 |
+| arrowIcon | IconData? | - | 自定义箭头图标 |
+| builder | TDropdownItemBuilder? | - | 下拉菜单构建器，优先级高于[items] |
+| closeOnClickOverlay | bool? | true | 是否在点击遮罩层后关闭菜单 |
+| decoration | Decoration? | - | 下拉菜单的装饰器 |
+| direction | TDropdownMenuDirection? | TDropdownMenuDirection.auto | 菜单展开方向（down、up、auto） |
+| duration | double? | 200.0 | 动画时长，毫秒 |
+| height | double? | 48 | menu的高度 |
+| isScrollable | bool? | false | 是否开启滚动列表 |
+| items | List<TDropdownItem>? | - | 下拉菜单 |
+| key |  | - |  |
+| labelBuilder | LabelBuilder? | - | 自定义标签内容 |
+| onMenuClosed | ValueChanged<int>? | - | 关闭菜单事件 |
+| onMenuOpened | ValueChanged<int>? | - | 展开菜单事件 |
+| showOverlay | bool? | true | 是否显示遮罩层 |
+| tabBarAlign | MainAxisAlignment? | MainAxisAlignment.center | [TDropdownItem.label]和[arrowIcon]/[TDropdownItem.arrowIcon]的对齐方式 |
+| width | double? | - | menu的宽度 |
+
 ```
 ```
 
@@ -319,30 +341,8 @@ TDropdownMenu _buildGroup(BuildContext context) {
 ```
 ```
 
-### TDropdownMenu
+### TDropdownItemController
 #### 简介
-下拉菜单
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| arrowColor | Color? | - | 自定义箭头颜色 |
-| arrowIcon | IconData? | - | 自定义箭头图标 |
-| builder | TDropdownItemBuilder? | - | 下拉菜单构建器，优先级高于[items] |
-| closeOnClickOverlay | bool? | true | 是否在点击遮罩层后关闭菜单 |
-| decoration | Decoration? | - | 下拉菜单的装饰器 |
-| direction | TDropdownMenuDirection? | TDropdownMenuDirection.auto | 菜单展开方向（down、up、auto） |
-| duration | double? | 200.0 | 动画时长，毫秒 |
-| height | double? | 48 | menu的高度 |
-| isScrollable | bool? | false | 是否开启滚动列表 |
-| items | List<TDropdownItem>? | - | 下拉菜单 |
-| key |  | - |  |
-| labelBuilder | LabelBuilder? | - | 自定义标签内容 |
-| onMenuClosed | ValueChanged<int>? | - | 关闭菜单事件 |
-| onMenuOpened | ValueChanged<int>? | - | 展开菜单事件 |
-| showOverlay | bool? | true | 是否显示遮罩层 |
-| tabBarAlign | MainAxisAlignment? | MainAxisAlignment.center | [TDropdownItem.label]和[arrowIcon]/[TDropdownItem.arrowIcon]的对齐方式 |
-| width | double? | - | menu的宽度 |
-
+下拉菜单控制器
 
   

--- a/tdesign-site/src/form/README.md
+++ b/tdesign-site/src/form/README.md
@@ -709,6 +709,35 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 
 ## API
+### TForm
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| btnGroup | List<Widget>? | - | 表单按钮组 |
+| colon | bool? | false | 是否在表单标签字段右侧显示冒号 |
+| data | Map<String, dynamic> | - | 表单数据 |
+| disabled | bool | false | 是否禁用整个表单 |
+| errorMessage | Object? | - | 表单信息错误信息配置 |
+| formContentAlign | TextAlign | TextAlign.left | 表单内容对齐方式: 左对齐、右对齐、居中对齐 |
+| formController | FormController? | - | 表单控制器 |
+| formLabelAlign | TextAlign? | TextAlign.left | 表单字段标签的对齐方式： |
+| formShowErrorMessage | bool? | true | 校验不通过时，是否显示错误提示信息，统一控制全部表单项 |
+| isHorizontal | bool | true | 表单排列方式是否为 水平方向 |
+| items | List<TFormItem> | - | 表单内容 items |
+| key |  | - |  |
+| labelWidth | double? | 20.0 | 可以整体设置 label 标签宽度 |
+| onReset | Function? | - | 表单重置时触发 |
+| onSubmit | Function | - | 表单提交时触发 |
+| preventSubmitDefault | bool? | true | 是否阻止表单提交默认事件（表单提交默认事件会刷新页面） |
+| requiredMark | bool? | true | 是否显示必填符号（*），默认显示 |
+| rules | Map<String, TFormValidation> | - | 整个表单字段校验规则 |
+| scrollToFirstError | String? | - | 表单校验不通过时，是否自动滚动到第一个校验不通过的字段，平滑滚动或是瞬间直达。 |
+| submitWithWarningMessage | bool? | false | 【讨论中】当校验结果只有告警信息时，是否触发 submit 提交事件 |
+
+```
+```
+
 ### TFormItem
 #### 默认构造方法
 
@@ -749,35 +778,6 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | errorMessage | String | - | 错误提示信息 |
 | type | TFormItemType | - | 校验对象的类型 |
 | validate | String? Function(dynamic) | - | 校验方法 |
-
-```
-```
-
-### TForm
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| btnGroup | List<Widget>? | - | 表单按钮组 |
-| colon | bool? | false | 是否在表单标签字段右侧显示冒号 |
-| data | Map<String, dynamic> | - | 表单数据 |
-| disabled | bool | false | 是否禁用整个表单 |
-| errorMessage | Object? | - | 表单信息错误信息配置 |
-| formContentAlign | TextAlign | TextAlign.left | 表单内容对齐方式: 左对齐、右对齐、居中对齐 |
-| formController | FormController? | - | 表单控制器 |
-| formLabelAlign | TextAlign? | TextAlign.left | 表单字段标签的对齐方式： |
-| formShowErrorMessage | bool? | true | 校验不通过时，是否显示错误提示信息，统一控制全部表单项 |
-| isHorizontal | bool | true | 表单排列方式是否为 水平方向 |
-| items | List<TFormItem> | - | 表单内容 items |
-| key |  | - |  |
-| labelWidth | double? | 20.0 | 可以整体设置 label 标签宽度 |
-| onReset | Function? | - | 表单重置时触发 |
-| onSubmit | Function | - | 表单提交时触发 |
-| preventSubmitDefault | bool? | true | 是否阻止表单提交默认事件（表单提交默认事件会刷新页面） |
-| requiredMark | bool? | true | 是否显示必填符号（*），默认显示 |
-| rules | Map<String, TFormValidation> | - | 整个表单字段校验规则 |
-| scrollToFirstError | String? | - | 表单校验不通过时，是否自动滚动到第一个校验不通过的字段，平滑滚动或是瞬间直达。 |
-| submitWithWarningMessage | bool? | false | 【讨论中】当校验结果只有告警信息时，是否触发 submit 提交事件 |
 
 
   

--- a/tdesign-site/src/image-viewer/README.md
+++ b/tdesign-site/src/image-viewer/README.md
@@ -69,6 +69,17 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 
 ## API
+### TImageViewer
+
+#### 静态方法
+
+| 名称 | 返回类型 | 参数 | 说明 |
+| --- | --- | --- | --- |
+| showImageViewer |  |   required BuildContext context,  required List<dynamic> images,  List<String>? labels,  bool? closeBtn,  bool? deleteBtn,  bool? showIndex,  bool? loop,  bool? autoplay,  int? duration,  Color? bgColor,  Color? navBarBgColor,  Color? iconColor,  TextStyle? labelStyle,  TextStyle? indexStyle,  Color? modalBarrierColor,  bool? barrierDismissible,  int? defaultIndex,  double? width,  double? height,  OnIndexChange? onIndexChange,  OnClose? onClose,  OnDelete? onDelete,  bool? ignoreDeleteError,  OnImageTap? onTap,  OnLongPress? onLongPress,  LeftItemBuilder? leftItemBuilder,  RightItemBuilder? rightItemBuilder, | 显示图片预览 |
+
+```
+```
+
 ### TImageViewerWidget
 #### 默认构造方法
 
@@ -99,17 +110,6 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | rightItemBuilder | RightItemBuilder? | - | 右侧自定义操作 |
 | showIndex | bool? | - | 是否显示页码 |
 | width | double? | - | 图片宽度 |
-
-```
-```
-
-### TImageViewer
-
-#### 静态方法
-
-| 名称 | 返回类型 | 参数 | 说明 |
-| --- | --- | --- | --- |
-| showImageViewer |  |   required BuildContext context,  required List<dynamic> images,  List<String>? labels,  bool? closeBtn,  bool? deleteBtn,  bool? showIndex,  bool? loop,  bool? autoplay,  int? duration,  Color? bgColor,  Color? navBarBgColor,  Color? iconColor,  TextStyle? labelStyle,  TextStyle? indexStyle,  Color? modalBarrierColor,  bool? barrierDismissible,  int? defaultIndex,  double? width,  double? height,  OnIndexChange? onIndexChange,  OnClose? onClose,  OnDelete? onDelete,  bool? ignoreDeleteError,  OnImageTap? onTap,  OnLongPress? onLongPress,  LeftItemBuilder? leftItemBuilder,  RightItemBuilder? rightItemBuilder, | 显示图片预览 |
 
 
   

--- a/tdesign-site/src/indexes/README.md
+++ b/tdesign-site/src/indexes/README.md
@@ -205,6 +205,30 @@ Widget _buildOther(BuildContext context) {
 
 
 ## API
+### TIndexes
+#### 简介
+索引
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| builderAnchor | Widget? Function(BuildContext context, String index, bool isPinnedToTop)? | - | 锚点自定义构建 |
+| builderContent | Widget? Function(BuildContext context, String index) | - | 内容自定义构建 |
+| builderIndex | Widget Function(BuildContext context, String index, bool isActive)? | - | 索引文本自定义构建，包括索引激活左侧提示 |
+| capsuleTheme | bool? | false | 锚点是否为胶囊式样式 |
+| indexList | List<String>? | - | 索引字符列表。不传默认 A-Z |
+| indexListMaxHeight | double? | 0.8 | 索引列表最大高度（父容器高度的百分比，默认 0.8） |
+| key |  | - |  |
+| onChange | void Function(String index)? | - | 索引发生变更时触发事件 |
+| onSelect | void Function(String index)? | - | 点击侧边栏时触发事件 |
+| reverse | bool? | false | 反方向滚动置顶 |
+| scrollController | ScrollController? | - | 滚动控制器 |
+| sticky | bool? | true | 锚点是否吸顶 |
+| stickyOffset | double? | 0 | 锚点吸顶时与顶部的距离 |
+
+```
+```
+
 ### TIndexesAnchor
 #### 简介
 索引锚点
@@ -235,30 +259,6 @@ Widget _buildOther(BuildContext context) {
 | indexListMaxHeight | double | 0.8 | 索引列表最大高度（父容器高度的百分比，默认0.8） |
 | key |  | - |  |
 | onSelect | void Function(String newIndex, String oldIndex) | - | 点击侧边栏时触发事件 |
-
-```
-```
-
-### TIndexes
-#### 简介
-索引
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| builderAnchor | Widget? Function(BuildContext context, String index, bool isPinnedToTop)? | - | 锚点自定义构建 |
-| builderContent | Widget? Function(BuildContext context, String index) | - | 内容自定义构建 |
-| builderIndex | Widget Function(BuildContext context, String index, bool isActive)? | - | 索引文本自定义构建，包括索引激活左侧提示 |
-| capsuleTheme | bool? | false | 锚点是否为胶囊式样式 |
-| indexList | List<String>? | - | 索引字符列表。不传默认 A-Z |
-| indexListMaxHeight | double? | 0.8 | 索引列表最大高度（父容器高度的百分比，默认 0.8） |
-| key |  | - |  |
-| onChange | void Function(String index)? | - | 索引发生变更时触发事件 |
-| onSelect | void Function(String index)? | - | 点击侧边栏时触发事件 |
-| reverse | bool? | false | 反方向滚动置顶 |
-| scrollController | ScrollController? | - | 滚动控制器 |
-| sticky | bool? | true | 锚点是否吸顶 |
-| stickyOffset | double? | 0 | 锚点吸顶时与顶部的距离 |
 
 
   

--- a/tdesign-site/src/input/README.md
+++ b/tdesign-site/src/input/README.md
@@ -684,6 +684,49 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 </td-code-block>
                                   
 
+登录场景：双密码框焦点切换不收键盘
+            
+<td-code-block panel="Dart">
+
+  <pre slot="Dart" lang="javascript">
+  Widget _specialTypeLoginForm(BuildContext context) {
+    // 登录场景：上下两个密码框，演示 issue #763 的修复效果。
+    // - 点击任一密码框：键盘应立即弹出（无需点两次）
+    // - 在两个密码框间切换焦点：键盘保持显示，不会被默认 onTapOutside 收起
+    // - 借助 AutofillGroup + AutofillHints.password 触发系统密码自动填充
+    return AutofillGroup(
+      child: Column(
+        children: [
+          TInput(
+            type: TInputType.normal,
+            controller: controller[28],
+            obscureText: true,
+            leftLabel: '密码',
+            hintText: '请输入密码',
+            autofillHints: const [AutofillHints.password],
+            inputAction: TextInputAction.next,
+            needClear: false,
+          ),
+          const SizedBox(height: 8),
+          TInput(
+            type: TInputType.normal,
+            controller: controller[29],
+            obscureText: true,
+            leftLabel: '确认密码',
+            hintText: '请再次输入密码',
+            autofillHints: const [AutofillHints.password],
+            inputAction: TextInputAction.done,
+            needClear: false,
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }</pre>
+
+</td-code-block>
+                                  
+
 
       
 <td-code-block panel="Dart">
@@ -1021,6 +1064,7 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | --- | --- | --- | --- |
 | additionInfo | String? | '' | 错误提示信息 |
 | additionInfoColor | Color? | - | 错误提示颜色 |
+| autofillHints | Iterable<String>? | - | 自动填充提示，例如密码框可传 `[AutofillHints.password]`，让系统/输入法 |
 | autofocus | bool | false | 是否自动获取焦点 |
 | backgroundColor | Color? | - | 输入框背景色 |
 | cardStyle | TCardStyle? | - | 卡片默认样式 |
@@ -1058,6 +1102,7 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | onChanged | ValueChanged<String>? | - | 输入文本变化时回调 |
 | onClearTap | GestureTapCallback? | - | 右侧删除点击 |
 | onEditingComplete | VoidCallback? | - | 点击键盘完成按钮时触发的回调 |
+| onLabelTap | GestureTapCallback? | - | 点击左侧 leftIcon / leftLabel 区域时的回调。 |
 | onSubmitted | ValueChanged<String>? | - | 点击键盘完成按钮时触发的回调, 参数值为输入的内容 |
 | onTapOutside | TapRegionCallback? | - | 点击输入框外部区域回调 |
 | readOnly | bool | false | 是否只读 |

--- a/tdesign-site/src/message/README.md
+++ b/tdesign-site/src/message/README.md
@@ -286,30 +286,6 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 
 ## API
-### MessageLink
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| color | Color? | - | 颜色 |
-| name | String | - | 名称 |
-| uri | Uri? | - | 资源链接 |
-
-```
-```
-
-### MessageMarquee
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| delay | int? | - | 延迟时间(毫秒) |
-| loop | int? | - | 循环次数 |
-| speed | int? | - | 速度 |
-
-```
-```
-
 ### TMessage
 #### 默认构造方法
 
@@ -335,6 +311,30 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | 名称 | 返回类型 | 参数 | 说明 |
 | --- | --- | --- | --- |
 | showMessage |  |   required BuildContext context,  String? content,  bool? visible,  int? duration,  dynamic closeBtn,  dynamic icon,  dynamic link,  MessageMarquee? marquee,  List<double>? offset,  MessageTheme? theme,  VoidCallback? onCloseBtnClick,  VoidCallback? onDurationEnd,  VoidCallback? onLinkClick, |  |
+
+```
+```
+
+### MessageMarquee
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| delay | int? | - | 延迟时间(毫秒) |
+| loop | int? | - | 循环次数 |
+| speed | int? | - | 速度 |
+
+```
+```
+
+### MessageLink
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| color | Color? | - | 颜色 |
+| name | String | - | 名称 |
+| uri | Uri? | - | 资源链接 |
 
 
   

--- a/tdesign-site/src/notice-bar/README.md
+++ b/tdesign-site/src/notice-bar/README.md
@@ -285,30 +285,6 @@ Widget _cardNoticeBar(BuildContext context) {
 
 
 ## API
-### TNoticeBarStyle
-#### 简介
-公告栏样式
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| backgroundColor | Color? | - | 公告栏背景色 |
-| context | BuildContext? | - | 上下文 |
-| leftIconColor | Color? | - | 公告栏左侧图标颜色 |
-| padding | EdgeInsetsGeometry? | - | 公告栏内边距 |
-| rightIconColor | Color? | - | 公告栏右侧图标颜色 |
-| textStyle | TextStyle? | - | 公告栏内容样式 |
-
-
-#### 工厂构造方法
-
-| 名称  | 说明 |
-| --- |  --- |
-| TNoticeBarStyle.generateTheme  | 根据主题生成样式 |
-
-```
-```
-
 ### TNoticeBar
 #### 简介
 
@@ -332,6 +308,30 @@ Widget _cardNoticeBar(BuildContext context) {
 | style | TNoticeBarStyle? | - | 公告栏样式 [TNoticeBarStyle] |
 | suffixIcon | IconData? | - | 右侧图标 |
 | theme | TNoticeBarTheme? | TNoticeBarTheme.info | 主题 |
+
+```
+```
+
+### TNoticeBarStyle
+#### 简介
+公告栏样式
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| backgroundColor | Color? | - | 公告栏背景色 |
+| context | BuildContext? | - | 上下文 |
+| leftIconColor | Color? | - | 公告栏左侧图标颜色 |
+| padding | EdgeInsetsGeometry? | - | 公告栏内边距 |
+| rightIconColor | Color? | - | 公告栏右侧图标颜色 |
+| textStyle | TextStyle? | - | 公告栏内容样式 |
+
+
+#### 工厂构造方法
+
+| 名称  | 说明 |
+| --- |  --- |
+| TNoticeBarStyle.generateTheme  | 根据主题生成样式 |
 
 
   

--- a/tdesign-site/src/picker/README.md
+++ b/tdesign-site/src/picker/README.md
@@ -480,29 +480,6 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 
 ## API
-### TPickerOption
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| disabled | bool | false | 是否禁用（不可选中/置灰显示），默认 false |
-| label | String | - | 展示文字（可包含 emoji、单位、国际化等） |
-| value | dynamic | - | 业务值（onChange 回调返回此字段） |
-
-```
-```
-
-### TPickerValue
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| indexes | List<int> | - | 每列选中项的索引 |
-| selectedOptions | List<TPickerOption> | - | 每列选中的完整 option |
-
-```
-```
-
 ### TPicker
 #### 默认构造方法
 
@@ -528,7 +505,39 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 ```
 ```
 
-### TPickerItems
+### TPickerOption
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| disabled | bool | false | 是否禁用（不可选中/置灰显示），默认 false |
+| label | String | - | 展示文字（可包含 emoji、单位、国际化等） |
+| value | dynamic | - | 业务值（onChange 回调返回此字段） |
+
+```
+```
+
+### TPickerValue
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| indexes | List<int> | - | 每列选中项的索引 |
+| selectedOptions | List<TPickerOption> | - | 每列选中的完整 option |
+
+```
+```
+
+### TPickerLoadEvent
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| column | int | - | 触发事件的列索引（0 表示第一列） |
+| displayedCount | int | - | 当前列已展示的选项总数 |
+| parentValue | dynamic | - | 当前列的父级选中值（联动模式下使用） |
+| remaining | int | - | 距底部剩余的选项数（业务可用此值做"接近底部时加载"判断） |
+
 ```
 ```
 
@@ -580,6 +589,10 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 ```
 ```
 
+### TPickerItems
+```
+```
+
 ### TPickerKeys
 #### 默认构造方法
 
@@ -589,19 +602,6 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | disabled | String | 'disabled' | 禁用标记对应的字段名，默认 `disabled` |
 | label | String | 'label' | 展示文案对应的字段名，默认 `label` |
 | value | String | 'value' | 业务值对应的字段名，默认 `value` |
-
-```
-```
-
-### TPickerLoadEvent
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| column | int | - | 触发事件的列索引（0 表示第一列） |
-| displayedCount | int | - | 当前列已展示的选项总数 |
-| parentValue | dynamic | - | 当前列的父级选中值（联动模式下使用） |
-| remaining | int | - | 距底部剩余的选项数（业务可用此值做"接近底部时加载"判断） |
 
 
   

--- a/tdesign-site/src/popover/README.md
+++ b/tdesign-site/src/popover/README.md
@@ -1275,6 +1275,19 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 
 ## API
+### TPopover
+#### 简介
+
+
+#### 静态方法
+
+| 名称 | 返回类型 | 参数 | 说明 |
+| --- | --- | --- | --- |
+| showPopover |  |   required BuildContext context,  String? content,  Widget? contentWidget,  double offset,  TPopoverTheme? theme,  bool closeOnClickOutside,  TPopoverPlacement? placement,  bool? showArrow,  double arrowSize,  EdgeInsetsGeometry? padding,  double? width,  double? height,  Color? overlayColor,  OnTap? onTap,  OnLongTap? onLongTap,  BorderRadius? radius, |  |
+
+```
+```
+
 ### TPopoverWidget
 #### 简介
 
@@ -1297,19 +1310,6 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | showArrow | bool? | true | 是否显示浮层箭头 |
 | theme | TPopoverTheme? | - | 弹出气泡主题 |
 | width | double? | - | 内容宽度（包含padding，实际高度：height - paddingLeft - paddingRight） |
-
-```
-```
-
-### TPopover
-#### 简介
-
-
-#### 静态方法
-
-| 名称 | 返回类型 | 参数 | 说明 |
-| --- | --- | --- | --- |
-| showPopover |  |   required BuildContext context,  String? content,  Widget? contentWidget,  double offset,  TPopoverTheme? theme,  bool closeOnClickOutside,  TPopoverPlacement? placement,  bool? showArrow,  double arrowSize,  EdgeInsetsGeometry? padding,  double? width,  double? height,  Color? overlayColor,  OnTap? onTap,  OnLongTap? onLongTap,  BorderRadius? radius, |  |
 
 
   

--- a/tdesign-site/src/popup/README.md
+++ b/tdesign-site/src/popup/README.md
@@ -459,6 +459,32 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 
 ## API
+### TSlidePopupRoute
+#### 简介
+从屏幕的某个方向滑动弹出的Dialog框的路由，比如从顶部、底部、左、右滑出页面
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| barrierClick | VoidCallback? | - | 蒙层点击事件，仅在[modalBarrierFull]为false时触发 |
+| barrierLabel |  | - |  |
+| builder | WidgetBuilder | - | 控件构建器 |
+| close | VoidCallback? | - | 关闭前事件 |
+| focusMove | bool | false | 是否有输入框获取焦点时整体平移避免输入框被遮挡 |
+| isDismissible | bool | true | 点击蒙层能否关闭 |
+| modalBarrierColor | Color? | Colors.black54 | 蒙层颜色 |
+| modalBarrierFull | bool | false | 是否全屏显示蒙层 |
+| modalHeight | double? | - | 弹出框高度 |
+| modalLeft | double? | 0 | 弹出框左侧距离 |
+| modalTop | double? | 0 | 弹出框顶部距离 |
+| modalWidth | double? | - | 弹出框宽度 |
+| open | VoidCallback? | - | 打开前事件 |
+| opened | VoidCallback? | - | 打开后事件 |
+| slideTransitionFrom | SlideTransitionFrom | SlideTransitionFrom.bottom | 设置从屏幕的哪个方向滑出 |
+
+```
+```
+
 ### TPopupBottomDisplayPanel
 #### 简介
 右上角带关闭的底部浮层面板
@@ -529,32 +555,6 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | closeUnderBottom | bool | false | 关闭按钮是否在视图框下方 |
 | key |  | - |  |
 | radius | double? | - | 圆角 |
-
-```
-```
-
-### TSlidePopupRoute
-#### 简介
-从屏幕的某个方向滑动弹出的Dialog框的路由，比如从顶部、底部、左、右滑出页面
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| barrierClick | VoidCallback? | - | 蒙层点击事件，仅在[modalBarrierFull]为false时触发 |
-| barrierLabel |  | - |  |
-| builder | WidgetBuilder | - | 控件构建器 |
-| close | VoidCallback? | - | 关闭前事件 |
-| focusMove | bool | false | 是否有输入框获取焦点时整体平移避免输入框被遮挡 |
-| isDismissible | bool | true | 点击蒙层能否关闭 |
-| modalBarrierColor | Color? | Colors.black54 | 蒙层颜色 |
-| modalBarrierFull | bool | false | 是否全屏显示蒙层 |
-| modalHeight | double? | - | 弹出框高度 |
-| modalLeft | double? | 0 | 弹出框左侧距离 |
-| modalTop | double? | 0 | 弹出框顶部距离 |
-| modalWidth | double? | - | 弹出框宽度 |
-| open | VoidCallback? | - | 打开前事件 |
-| opened | VoidCallback? | - | 打开后事件 |
-| slideTransitionFrom | SlideTransitionFrom | SlideTransitionFrom.bottom | 设置从屏幕的哪个方向滑出 |
 
 
   

--- a/tdesign-site/src/side-bar/README.md
+++ b/tdesign-site/src/side-bar/README.md
@@ -635,22 +635,6 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 
 ## API
-### TSideBarItem
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| badge | TBadge? | - | 徽标 |
-| disabled | bool | false | 是否禁用 |
-| icon | IconData? | - | 图标 |
-| key |  | - |  |
-| label | String | '' | 标签 |
-| textStyle | TextStyle? | - | 标签样式 |
-| value | int | -1 | 值 |
-
-```
-```
-
 ### TSideBar
 #### 默认构造方法
 
@@ -673,6 +657,22 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | unSelectedBgColor | Color? | - | 未选择的背景颜色 |
 | unSelectedColor | Color? | - | 未选中颜色 |
 | value | int? | - | 选项值 |
+
+```
+```
+
+### TSideBarItem
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| badge | TBadge? | - | 徽标 |
+| disabled | bool | false | 是否禁用 |
+| icon | IconData? | - | 图标 |
+| key |  | - |  |
+| label | String | '' | 标签 |
+| textStyle | TextStyle? | - | 标签样式 |
+| value | int | -1 | 值 |
 
 
   

--- a/tdesign-site/src/steps/README.md
+++ b/tdesign-site/src/steps/README.md
@@ -703,21 +703,6 @@ Vertical Customize Steps 垂直自定义步骤条
 
 
 ## API
-### TStepsItemData
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| content | String? | - | 内容 |
-| customContent | Widget? | - | 自定义内容 |
-| customTitle | Widget? | - | 自定义标题 |
-| errorIcon | IconData? | - | 失败图标 |
-| successIcon | IconData? | - | 成功图标 |
-| title | String? | - | 标题 |
-
-```
-```
-
 ### TSteps
 #### 默认构造方法
 
@@ -731,6 +716,21 @@ Vertical Customize Steps 垂直自定义步骤条
 | status | TStepsStatus | TStepsStatus.success | 步骤条状态 |
 | steps | List<TStepsItemData> | - | 步骤条数据 |
 | verticalSelect | bool | false | 步骤条垂直自定义步骤条选择模式 |
+
+```
+```
+
+### TStepsItemData
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| content | String? | - | 内容 |
+| customContent | Widget? | - | 自定义内容 |
+| customTitle | Widget? | - | 自定义标题 |
+| errorIcon | IconData? | - | 失败图标 |
+| successIcon | IconData? | - | 成功图标 |
+| title | String? | - | 标题 |
 
 
   

--- a/tdesign-site/src/swiper/README.md
+++ b/tdesign-site/src/swiper/README.md
@@ -267,6 +267,21 @@ import 'package:flutter_swiper_null_safety/flutter_swiper_null_safety.dart';
 
 
 ## API
+### TSwiperPagination
+#### 简介
+TDesign风格的Swiper指示器样式，与flutter_swiper的Swiper结合使用
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| alignment | Alignment? | - | 当 scrollDirection== Axis.horizontal 时，默认Alignment.bottomCenter |
+| builder | SwiperPlugin | TSwiperPagination.dots | 具体样式 |
+| key | Key? | - |  |
+| margin | EdgeInsetsGeometry | const EdgeInsets.all(10.0) | 指示器和container之间的距离 |
+
+```
+```
+
 ### TPageTransformer
 #### 简介
 TD默认PageTransformer
@@ -285,21 +300,6 @@ TD默认PageTransformer
 | --- |  --- |
 | TPageTransformer.margin  | 普通margin的卡片式 |
 | TPageTransformer.scaleAndFade  | 缩放或透明的卡片式 |
-
-```
-```
-
-### TSwiperPagination
-#### 简介
-TDesign风格的Swiper指示器样式，与flutter_swiper的Swiper结合使用
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| alignment | Alignment? | - | 当 scrollDirection== Axis.horizontal 时，默认Alignment.bottomCenter |
-| builder | SwiperPlugin | TSwiperPagination.dots | 具体样式 |
-| key | Key? | - |  |
-| margin | EdgeInsetsGeometry | const EdgeInsets.all(10.0) | 指示器和container之间的距离 |
 
 
   

--- a/tdesign-site/src/tab-bar/README.md
+++ b/tdesign-site/src/tab-bar/README.md
@@ -571,38 +571,6 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 
 ## API
-### BadgeConfig
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| badgeRightOffset | double? | - | 消息右侧偏移量 |
-| badgeTopOffset | double? | - | 消息顶部偏移量 |
-| showBadge | bool | - | 是否展示消息 |
-| tBadge | TBadge? | - | 消息样式（未设置但 showBadge 为 true，则默认使用红点） |
-
-```
-```
-
-### TBottomTabBarTabConfig
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| allowMultipleTaps | bool | false | onTap 方法允许点击多次 |
-| badgeConfig | BadgeConfig? | - | 消息配置 |
-| onLongPress | GestureLongPressCallback? | - | 长按事件 |
-| onTap | GestureTapCallback? | - | tab点击事件 |
-| popUpButtonConfig | TBottomTabBarPopUpBtnConfig? | - | 弹窗配置 |
-| selectedIcon | Widget? | - | 选中时图标 |
-| selectTabTextStyle | TextStyle? | - | 文本已选择样式 basicType为text时必填 |
-| tabText | String? | - | tab 文本 |
-| unselectedIcon | Widget? | - | 未选中时图标 |
-| unselectTabTextStyle | TextStyle? | - | 文本未选择样式 basicType为text时必填 |
-
-```
-```
-
 ### TBottomTabBar
 #### 默认构造方法
 
@@ -631,6 +599,38 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | unselectedBgColor | Color? | - | 未选中时背景颜色 |
 | useSafeArea | bool | true | 使用安全区域 |
 | useVerticalDivider | bool? | - | 是否使用竖线分隔（如果选项样式为 label，则强制为 false） |
+
+```
+```
+
+### BadgeConfig
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| badgeRightOffset | double? | - | 消息右侧偏移量 |
+| badgeTopOffset | double? | - | 消息顶部偏移量 |
+| showBadge | bool | - | 是否展示消息 |
+| tBadge | TBadge? | - | 消息样式（未设置但 showBadge 为 true，则默认使用红点） |
+
+```
+```
+
+### TBottomTabBarTabConfig
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| allowMultipleTaps | bool | false | onTap 方法允许点击多次 |
+| badgeConfig | BadgeConfig? | - | 消息配置 |
+| onLongPress | GestureLongPressCallback? | - | 长按事件 |
+| onTap | GestureTapCallback? | - | tab点击事件 |
+| popUpButtonConfig | TBottomTabBarPopUpBtnConfig? | - | 弹窗配置 |
+| selectedIcon | Widget? | - | 选中时图标 |
+| selectTabTextStyle | TextStyle? | - | 文本已选择样式 basicType为text时必填 |
+| tabText | String? | - | tab 文本 |
+| unselectedIcon | Widget? | - | 未选中时图标 |
+| unselectTabTextStyle | TextStyle? | - | 文本未选择样式 basicType为text时必填 |
 
 ```
 ```

--- a/tdesign-site/src/tabs/README.md
+++ b/tdesign-site/src/tabs/README.md
@@ -308,19 +308,6 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 
 ## API
-### TTabBarView
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| children | List<Widget> | - | 子widget列表 |
-| controller | TabController? | - | 控制器 |
-| isSlideSwitch | bool | false | 是否可以滑动切换 |
-| key |  | - |  |
-
-```
-```
-
 ### TTabBar
 #### 默认构造方法
 
@@ -374,6 +361,19 @@ import 'package:tdesign_flutter/tdesign_flutter.dart';
 | size | TTabSize | TTabSize.small | 选项卡尺寸 |
 | text | String? | - | 文字内容 |
 | textMargin | EdgeInsetsGeometry? | - | 中间内容宽度 |
+
+```
+```
+
+### TTabBarView
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| children | List<Widget> | - | 子widget列表 |
+| controller | TabController? | - | 控制器 |
+| isSlideSwitch | bool | false | 是否可以滑动切换 |
+| key |  | - |  |
 
 
   

--- a/tdesign-site/src/time-counter/README.md
+++ b/tdesign-site/src/time-counter/README.md
@@ -608,6 +608,31 @@ TTimeCounter _buildCustomUnitLargeSize(BuildContext context) {
 
 
 ## API
+### TTimeCounter
+#### 简介
+计时组件
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| autoStart | bool | true | 是否自动开始倒计时 |
+| content | dynamic | 'default' | 'default' / Widget Function(int time) / Widget |
+| controller | TTimeCounterController? | - | 控制器，可控制开始/暂停/继续/重置 |
+| direction | TTimeCounterDirection | TTimeCounterDirection.down | 计时方向，默认倒计时 |
+| format | String | 'HH:mm:ss' | 时间格式，DD-日，HH-时，mm-分，ss-秒，SSS-毫秒（分隔符必须为长度为1的非空格的字符） |
+| key |  | - |  |
+| millisecond | bool | false | 是否开启毫秒级渲染 |
+| onChange |  Function(int time)? | - | 时间变化时触发回调 |
+| onFinish | VoidCallback? | - | 计时结束时触发回调 |
+| size | TTimeCounterSize | TTimeCounterSize.medium | 尺寸 |
+| splitWithUnit | bool | false | 使用时间单位分割 |
+| style | TTimeCounterStyle? | - | 自定义样式，有则优先用它，没有则根据size和theme选取 |
+| theme | TTimeCounterTheme | TTimeCounterTheme.defaultTheme | 风格 |
+| time | int | - | 必需；计时时长，单位毫秒 |
+
+```
+```
+
 ### TTimeCounterController
 #### 简介
 倒计时组件控制器，可控制开始(`start()`)/暂停(`pause()`)/继续(`resume()`)/重置(`reset([int? time])`)
@@ -643,31 +668,6 @@ TTimeCounter _buildCustomUnitLargeSize(BuildContext context) {
 | 名称  | 说明 |
 | --- |  --- |
 | TTimeCounterStyle.generateStyle  | 生成默认样式 |
-
-```
-```
-
-### TTimeCounter
-#### 简介
-计时组件
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| autoStart | bool | true | 是否自动开始倒计时 |
-| content | dynamic | 'default' | 'default' / Widget Function(int time) / Widget |
-| controller | TTimeCounterController? | - | 控制器，可控制开始/暂停/继续/重置 |
-| direction | TTimeCounterDirection | TTimeCounterDirection.down | 计时方向，默认倒计时 |
-| format | String | 'HH:mm:ss' | 时间格式，DD-日，HH-时，mm-分，ss-秒，SSS-毫秒（分隔符必须为长度为1的非空格的字符） |
-| key |  | - |  |
-| millisecond | bool | false | 是否开启毫秒级渲染 |
-| onChange |  Function(int time)? | - | 时间变化时触发回调 |
-| onFinish | VoidCallback? | - | 计时结束时触发回调 |
-| size | TTimeCounterSize | TTimeCounterSize.medium | 尺寸 |
-| splitWithUnit | bool | false | 使用时间单位分割 |
-| style | TTimeCounterStyle? | - | 自定义样式，有则优先用它，没有则根据size和theme选取 |
-| theme | TTimeCounterTheme | TTimeCounterTheme.defaultTheme | 风格 |
-| time | int | - | 必需；计时时长，单位毫秒 |
 
 
   

--- a/tdesign-site/src/tree-select/README.md
+++ b/tdesign-site/src/tree-select/README.md
@@ -186,21 +186,6 @@ String类型ID(问题3)
 
 
 ## API
-### TSelectOption
-#### 默认构造方法
-
-| 参数 | 类型 | 默认值 | 说明 |
-| --- | --- | --- | --- |
-| children | List<TSelectOption> | const [] | 子选项 |
-| columnWidth | double? | - | 自定义宽度，允许用户指定每个选项的宽度 |
-| label | String | - | 标签 |
-| maxLines | int | 1 | 最大显示行数 |
-| multiple | bool | false | 当前子项支持多选 |
-| value | dynamic | - | 值 |
-
-```
-```
-
 ### TTreeSelect
 #### 默认构造方法
 
@@ -214,6 +199,21 @@ String类型ID(问题3)
 | options | List<TSelectOption> | const [] | 展示的选项列表 |
 | outwardCornerRadius | double | 9 | 一级菜单选中项的外弯折圆角半径，默认为 9 |
 | style | TTreeSelectStyle | TTreeSelectStyle.normal | 一级菜单样式 |
+
+```
+```
+
+### TSelectOption
+#### 默认构造方法
+
+| 参数 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| children | List<TSelectOption> | const [] | 子选项 |
+| columnWidth | double? | - | 自定义宽度，允许用户指定每个选项的宽度 |
+| label | String | - | 标签 |
+| maxLines | int | 1 | 最大显示行数 |
+| multiple | bool | false | 当前子项支持多选 |
+| value | dynamic | - | 值 |
 
 
   


### PR DESCRIPTION
Fixes the following issue reported in #763:
Switching focus between two TInput password fields causes the soft keyboard to be dismissed instead of staying open (Android).

Root cause:
  TInputView passed onTapOutside straight through to TextField; when
  callers do not provide one, Flutter's default _defaultOnTapOutside
  unfocuses the current field, racing with the next field's
  requestFocus and causing the keyboard to flicker shut.

Changes:
  - TInput: label-area GestureDetector now uses HitTestBehavior. translucent and forwards an explicit onLabelTap, so taps fall through to the underlying TextField when no label handler is supplied.
  - TInput / TInputView: add new optional autofillHints parameter and forward it to TextField for proper system password autofill support.
  - TInputView: provide a no-op default onTapOutside so switching between multiple TInputs no longer dismisses the soft keyboard. Callers can still override it to restore the dismiss-on-tap- outside behaviour.
  - example: add a login-style demo with two consecutive password inputs to manually verify the fix.
  - test: add 7 widget tests under test/input/ covering all fix points (all passing).

Verified on:
  - iOS 17 (manual + automated tests)
  - Android MIUI (Redmi, manual): focus-switch fix is effective.

Known upstream limitation (out of scope):
  On MIUI / HyperOS, even a bare Flutter TextField(obscureText: true)
  requires two taps to bring up the IME on first interaction. This is
  a Flutter Engine + vendor IME compatibility issue and cannot be
  worked around in Dart-layer component code.

### 🤔 这个 PR 的性质是？
> 勾选规则:
> 1.只要有新增参数，就勾选”新特性提交“
> 2.只修改内部bug，未新增参数，才勾选”日常 bug 修复“
> 3.其他选项视具体改动判断x

- [ x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
- Closes #763
-->

### 💡 需求背景和解决方案

<!--
## 本 PR 修复的问题

### 1. 两个 TInput 之间切换焦点时，键盘不再被收起 ✅

**根因**：`TextField` 默认的 `onTapOutside` 会在指针落到输入框外部任意位置时调用 `focusNode.unfocus()`。当点击下一个 TInput 时，前一个输入框的 `onTapOutside` 会先于新输入框的 `requestFocus` 触发，造成键盘在切换中途被收起。

**修复**：`TInputView` 提供了一个空函数作为默认 `onTapOutside`。业务方如果仍需"点空白处收起键盘"的行为，可以显式传入 `onTapOutside` 覆盖默认值。

**验证情况**：
- ✅ iOS 26（iPhone 16e 模拟器）通过
- ✅ Android MIUI（红米真机）通过

### 2. Label 区点击事件不再被 GestureDetector 吸走 ✅

**根因**：包裹 `leftLabel` 的 `GestureDetector` 没有声明 `HitTestBehavior`，在某些平台上会被命中测试视为不透明，吸走第一次 tap，导致点击 label 区时下方 `TextField` 收不到事件。

**修复**：显式声明 `HitTestBehavior.translucent`，并加上 `onLabelTap` 回调。当业务方未传 `onLabelTap` 时，点击事件会穿透到下方 `TextField`，触发获焦和弹键盘。

### 3. 新增 `autofillHints` 参数 🆕

`TInput` 和 `TInputView` 新增可选参数 `autofillHints`，透传给底层 `TextField`。配合 `AutofillGroup` 使用，可让密码框等字段触发系统级自动填充（例如 `[AutofillHints.password]`）。

### 4. 新增 `onLabelTap` 回调 🆕

允许业务方拦截 label 区域的点击事件（例如点 label 弹出帮助提示），未传时保持原有的"穿透到输入框"行为，向后兼容。

---

## ⚠️ 已知局限（非本 PR 可解决）

在 MIUI / HyperOS 上，即使是**裸** `TextField(obscureText: true)`，首次点击也需要点两次才能唤起键盘。我们做了三种原生 `TextField` 同页对照实验来定位根因：

| 输入框类型 | 首次点击是否弹键盘 |
|---|---|
| `TextField()` 普通文本框 | ✅ 一次弹起 |
| `TextField(obscureText: true)` | ❌ 要点两次 |
| `TextField(obscureText: true, keyboardType: TextInputType.visiblePassword)` | ❌ 要点两次 |

**结论**：这是 Flutter Engine 层（`TextInputPlugin.java`）与厂商 IME 的兼容性问题——MIUI 的 `InputMethodManager` 会静默忽略 `PASSWORD` `InputType` 的首次 show 请求，**无法在 Dart 组件层兜底**。该问题需要 Flutter Engine 上游修复，不在本 PR 修复范围。

> 💡 issue #763 中提到的"切换两个密码框键盘被收起"这一诉求在 MIUI 上**已修复**；"首次点击不弹"这一诉求受上游 Engine 限制，不在本 PR 修复范围。

---

## 测试

- ✅ `test/input/t_input_test.dart` 新增 **7 个 widget test**，全部通过
- ✅ iOS 26（iPhone 16e 模拟器）手动验证通过
- ✅ Android（红米 MIUI）手动验证：双密码框切换焦点不收键盘 ✅ 生效
- ✅ `dart analyze` 0 错误

---

## Demo

`example` 工程的 TInput 示例页新增 demo：**"登录场景：双密码框焦点切换不收键盘"**，方便手动验证修复效果。

---
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] pr目标分支为develop分支，请勿直接往main分支合并
- [ ] 标题格式为：`组件类名`: 修改描述（示例：`TBottomTabBar`: 修复iconText模式，底部溢出2.5像素）
- [ ] ”相关issue“处带上修复的issue链接
- [ ] 相关文档已补充或无须补充
