### PR TITLE
TFab: expose onLongPress callback

### DIFF
--- a/requirements/issue-924-fab-on-long-press/TaskContract.md
+++ b/requirements/issue-924-fab-on-long-press/TaskContract.md
@@ -1,0 +1,38 @@
+# TaskContract — issue #924 [TDFab] 暴漏onLongPress方法
+
+## 基本信息
+
+- issue: https://github.com/Tencent/tdesign-flutter/issues/924
+- 组件：`TFab`（issue 标题中写作 `TDFab`）
+- 分支：`fix/issue-924-fab-on-long-press`
+- 目录：`requirements/issue-924-fab-on-long-press`
+- 类型：feature / enhancement
+
+## 问题描述
+
+- `TFab` 目前仅暴露点击回调 `onClick`，无法响应长按交互，导致业务侧无法实现“长按 FAB”触发动作的需求。
+
+## 根因分析
+
+- 组件内部使用 `InkWell` 仅绑定了 `onTap`，未对外提供 `onLongPress` 参数，也未将长按事件透传到 `InkWell.onLongPress`。
+
+## 修复方案
+
+1. 在 `TFab` 组件上新增 `VoidCallback? onLongPress` 公共参数（API 注释使用 `///`）。
+2. 在组件内部 `InkWell` 绑定 `onLongPress: onLongPress`，保持对现有 `onClick` 的兼容，不引入破坏性变更。
+3. 更新 `example` 的 FAB 页面，补充长按示例用于人工验收与回归。
+
+## 贡献指南对照
+
+- 开发规范：遵循 `CONTRIBUTING.md`，对原生组件行为“只扩展不阉割”；本次为新增事件回调，属于向后兼容扩展。
+- 代码 Review 自检：构造函数在字段前；公开 API 使用 `///`；组件样式仍来自 `TTheme.of(context)`，无额外硬编码。
+- 文档自检：本次变更为 API 扩展，已同步更新 example 示范用法；不涉及 `tdesign-site/src/**/README.md` 生成物。
+
+## 交付物清单
+
+| 序号 | 交付物 | 说明 |
+|------|--------|------|
+| 1 | `requirements/issue-924-fab-on-long-press/test-cases.md` | 验收用例 |
+| 2 | `requirements/issue-924-fab-on-long-press/code-review-report.md` | 代码审查结论 |
+| 3 | `requirements/issue-924-fab-on-long-press/acceptance-report.md` | 验收报告 |
+| 4 | `requirements/issue-924-fab-on-long-press/pr-body.md` | PR 摘要 |

--- a/requirements/issue-924-fab-on-long-press/acceptance-report.md
+++ b/requirements/issue-924-fab-on-long-press/acceptance-report.md
@@ -1,0 +1,37 @@
+# Acceptance Report — issue #924 [TDFab] 暴漏onLongPress方法
+
+## 验收结论
+
+状态：通过
+
+## 需求对照
+
+| 验收项 | 结果 | 说明 |
+|---|---|---|
+| `TFab` 暴露长按回调 `onLongPress` | 通过 | 新增可选参数并透传到 `InkWell.onLongPress` |
+| 保持对现有点击回调 `onClick` 的兼容 | 通过 | `onLongPress` 为可选参数，不影响原有点击行为 |
+| 提供可验收示例 | 通过 | `TFabPage` 新增 “LongPress 长按事件” 示例条目 |
+
+## 执行检查
+
+### 通过项
+
+```bash
+dart analyze tdesign-component/lib/src/components/fab/t_fab.dart
+node scripts/issue-workflow/check-issue-fix.mjs --requirements-dir requirements/issue-924-fab-on-long-press
+```
+
+### 未通过项或阻塞项
+
+- 无
+
+## 人工验收指引
+
+1. 运行 `tdesign-component/example`（按项目既有方式启动）。
+2. 进入 FAB 示例页（`TFabPage`）。
+3. 长按 “LongPress 长按事件” 示例中的 FAB，观察控制台输出 `TFab onLongPress`，并确认无异常报错。
+
+## 环境说明
+
+- OS：macOS（darwin）
+- 说明：验收以静态检查 + example 人工交互为主，不涉及站点生成物改动。

--- a/requirements/issue-924-fab-on-long-press/code-review-report.md
+++ b/requirements/issue-924-fab-on-long-press/code-review-report.md
@@ -1,0 +1,42 @@
+# Code Review Report — issue #924
+
+## 审查结论
+
+状态：通过
+
+## 修改范围
+
+- `tdesign-component/lib/src/components/fab/t_fab.dart`：为 `TFab` 新增 `onLongPress` 回调并透传到 `InkWell`。
+- `tdesign-component/example/lib/page/t_fab_page.dart`：新增长按示例条目，方便验收。
+
+## 规范检查
+
+### 1. 构造方法与字段顺序
+
+- 通过：构造方法在前，字段在后；新增字段 `onLongPress` 放在构造方法之后。
+
+### 2. 注释风格
+
+- 通过：新增公开 API 使用 `///` 注释。
+
+### 3. all_build 配置
+
+- 不涉及：未新增组件类与 demo_tool 生成入口，仅扩展现有 `TFab` 参数。
+
+### 4. TTheme 使用
+
+- 通过：本次仅新增事件回调，不修改主题/样式逻辑。
+
+### 5. TResourceDelegate 使用
+
+- 不涉及：本次仅新增事件回调；示例中使用 `debugPrint` 输出日志，不引入固定 UI 文案。
+
+## 正确性评审
+
+- 新增 `onLongPress` 为可选参数，默认行为与此前一致（未传入时不产生长按回调）。
+- `onClick` 与 `onLongPress` 可同时配置，交互由 `InkWell` 负责分发，符合 Flutter 常规行为。
+
+## 风险与未验证项
+
+- 风险较低：属于向后兼容的 API 扩展。
+- 未覆盖自动化 widget test：仓库当前未对 `TFab` 提供现成测试基础；本次通过 example 页面提供可复现验收路径。

--- a/requirements/issue-924-fab-on-long-press/pr-body.md
+++ b/requirements/issue-924-fab-on-long-press/pr-body.md
@@ -1,0 +1,49 @@
+## Summary
+
+- `TFab` 新增 `onLongPress` 回调，对外暴露长按事件（向后兼容，不影响原有 `onClick`）。
+- `example` 的 FAB 页面补充长按示例，便于验收与回归。
+
+## Root Cause
+
+- `TFab` 内部 `InkWell` 仅绑定 `onTap`，组件 API 未提供长按回调参数，导致业务侧无法接入长按交互。
+
+## Fix Plan
+
+- 在 `TFab` 上新增 `VoidCallback? onLongPress` 参数并透传到 `InkWell.onLongPress`。
+- 补充示例页面用法，方便开发者验证与参考。
+
+## Test Plan
+
+- `dart analyze tdesign-component/lib/src/components/fab/t_fab.dart`
+- 运行 `tdesign-component/example`，进入 `TFabPage`，长按 “LongPress 长按事件” 示例 FAB，观察控制台输出 `TFab onLongPress`。
+
+### 🔗 相关 Issue
+
+https://github.com/Tencent/tdesign-flutter/issues/924
+
+### 🤔 这个 PR 的性质是？
+
+- [ ] 日常 bug 修复
+- [x] 新特性提交
+- [ ] 文档改进
+- [x] 演示代码改进
+- [ ] 组件样式/交互改进
+- [ ] CI/CD 改进
+- [ ] 重构
+- [ ] 代码风格优化
+- [ ] 测试用例
+- [ ] 分支合并
+- [ ] 其他
+
+### 📝 更新日志
+
+- feat(TFab): expose `onLongPress` callback
+
+- [x] 本条 PR 不需要纳入 Changelog
+
+### ☑️ 请求合并前的自查清单
+
+- [x] pr目标分支为develop分支，请勿直接往main分支合并
+- [x] 标题格式为：`组件类名`: 修改描述（示例：`TBottomTabBar`: 修复iconText模式，底部溢出2.5像素）
+- [x] ”相关issue“处带上修复的issue链接
+- [x] 相关文档已补充或无须补充

--- a/requirements/issue-924-fab-on-long-press/test-cases.md
+++ b/requirements/issue-924-fab-on-long-press/test-cases.md
@@ -1,0 +1,19 @@
+# 测试用例 — issue #924 [TDFab] 暴漏onLongPress方法
+
+## TC-01
+
+- **前置条件**：运行 `tdesign-component/example`，进入 FAB 示例页（`TFabPage`）。
+- **操作**：对 “LongPress 长按事件” 示例中的 FAB 进行长按。
+- **期望**：控制台输出 `TFab onLongPress`；无异常报错；松手后按钮仍可继续交互。
+
+## TC-02
+
+- **前置条件**：同 TC-01。
+- **操作**：对任意示例 FAB 进行点击（Tap）。
+- **期望**：点击行为不受 `onLongPress` 新增影响；未配置 `onClick` 时点击无副作用且无异常。
+
+## TC-03
+
+- **前置条件**：在业务工程或示例中，构建 `TFab(onLongPress: ...)`。
+- **操作**：执行 `flutter analyze`（或仓库现有静态检查流程）。
+- **期望**：静态检查通过；对仅使用旧参数（不传 `onLongPress`）的代码保持兼容，无需改动即可编译通过。

--- a/tdesign-component/example/lib/page/t_fab_page.dart
+++ b/tdesign-component/example/lib/page/t_fab_page.dart
@@ -22,6 +22,9 @@ class _TFabPageState extends State<TFabPage> {
         ExampleItem(
             desc: 'Icon Fab with Text 图标加文字悬浮按钮', builder: _buildTextFab)
       ]),
+      ExampleModule(title: '事件', children: [
+        ExampleItem(desc: 'LongPress 长按事件', builder: _buildLongPressFab),
+      ]),
       ExampleModule(title: '组件状态', children: [
         ExampleItem(desc: 'Fab Theme 悬浮按钮主题', builder: _buildThemeFab),
         ExampleItem(desc: 'Fab Shape 悬浮按钮形状', builder: _buildShapeFab),
@@ -46,6 +49,18 @@ class _TFabPageState extends State<TFabPage> {
         theme: TFabTheme.primary,
         text: 'Floating',
       )
+    ]);
+  }
+
+  @Demo(group: 'fab')
+  Widget _buildLongPressFab(BuildContext context) {
+    return _buildRowDemo([
+      TFab(
+        theme: TFabTheme.primary,
+        onLongPress: () {
+          debugPrint('TFab onLongPress');
+        },
+      ),
     ]);
   }
 

--- a/tdesign-component/lib/src/components/fab/t_fab.dart
+++ b/tdesign-component/lib/src/components/fab/t_fab.dart
@@ -24,6 +24,7 @@ class TFab extends StatelessWidget {
     this.size = TFabSize.large,
     this.text,
     this.onClick,
+    this.onLongPress,
     this.icon,
   }) : super(key: key);
 
@@ -44,6 +45,9 @@ class TFab extends StatelessWidget {
 
   /// 点击事件
   final VoidCallback? onClick;
+
+  /// 长按事件
+  final VoidCallback? onLongPress;
 
   bool get showText => text?.isNotEmpty ?? false;
 
@@ -137,6 +141,7 @@ class TFab extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: onClick,
+      onLongPress: onLongPress,
       child: Container(
         padding: getPadding(),
         decoration: BoxDecoration(


### PR DESCRIPTION
## Summary

- `TFab` 新增 `onLongPress` 回调，对外暴露长按事件（向后兼容，不影响原有 `onClick`）。
- `example` 的 FAB 页面补充长按示例，便于验收与回归。

## Root Cause

- `TFab` 内部 `InkWell` 仅绑定 `onTap`，组件 API 未提供长按回调参数，导致业务侧无法接入长按交互。

## Fix Plan

- 在 `TFab` 上新增 `VoidCallback? onLongPress` 参数并透传到 `InkWell.onLongPress`。
- 补充示例页面用法，方便开发者验证与参考。

## Test Plan

- `dart analyze tdesign-component/lib/src/components/fab/t_fab.dart`
- 运行 `tdesign-component/example`，进入 `TFabPage`，长按 “LongPress 长按事件” 示例 FAB，观察控制台输出 `TFab onLongPress`。

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-flutter/issues/924

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 📝 更新日志

- feat(TFab): expose `onLongPress` callback

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] pr目标分支为develop分支，请勿直接往main分支合并
- [x] 标题格式为：`组件类名`: 修改描述（示例：`TBottomTabBar`: 修复iconText模式，底部溢出2.5像素）
- [x] ”相关issue“处带上修复的issue链接
- [x] 相关文档已补充或无须补充
