### PR TITLE
fix(popover): harden lifecycle and adaptive positioning

### DIFF
--- a/specs/003-popover-contract-hardening/acceptance.md
+++ b/specs/003-popover-contract-hardening/acceptance.md
@@ -1,0 +1,54 @@
+# 验收记录
+
+## 验证环境
+
+- 分支：develop
+- 基线提交：541f76435e0a492f9f392fe98f72e72167b24516
+- 实现状态：工作区未提交
+- Flutter：3.32.0 stable
+- Dart：3.8.0
+
+## 自动化验证
+
+| 命令 | 结果 | 备注 |
+| --- | --- | --- |
+| `flutter test test/components/popover/t_popover_test.dart test/components/popover/t_popover_golden_test.dart test/components/popup/t_popup_widget_test.dart test/components/popup/t_feedback_theme_data_test.dart test/components/popup/t_popup_theme_test.dart` | 通过 | 68 tests passed，覆盖 Popover、Golden、自动翻转、箭头补偿、锚点生命周期与关联 Popup/主题路径 |
+| `flutter analyze lib/src/components/popover test/components/popover` | 通过 | No issues found |
+| `flutter test test/popover_page_test.dart`（example） | 通过 | 4 tests passed，操作真实 Demo 覆盖事件、主题尺寸、窄屏、键盘和锚点销毁 |
+| `dart run tool/generate_example_code.dart --check` | 通过 | Demo 代码片段与源码同步 |
+| `flutter analyze lib/page/t_popover_page.dart test/popover_page_test.dart`（example） | 通过 | No issues found |
+| `flutter build web`（example） | 通过 | 实际 Example Web 发布入口编译成功 |
+| `node scripts/check-flutter-component-contracts.mjs` | 通过 | 56 site routes have source, Example, and docs entries |
+| `git diff --check` | 通过 | 无空白错误 |
+
+## 已验证行为
+
+- [x] onTap 与 onLongTap 分别触发并收到 content
+- [x] 无回调时外部点击关闭和底层滚动不受手势层阻断
+- [x] 主题 backgroundColor 覆盖默认语义背景色
+- [x] maxHeight 不再把短文本气泡撑到固定高度
+- [x] minWidth、maxWidth 和默认 300 宽度上限继续有效
+- [x] 右下角锚点的文本内容保持在 viewport 内
+- [x] top 空间不足时翻转到 bottom，left 空间不足时翻转到 right
+- [x] 两侧空间都不足时 clamp，箭头位移限制在圆角安全区内
+- [x] light/dark Golden 未变化
+- [x] Popup 关联主题和 Overlay 测试无回归
+- [x] Demo 中事件和自定义内容可交互，结果状态可观察
+- [x] Demo 中主题尺寸、窄屏边界和键盘可用区域可验证
+- [x] Demo 中移除锚点后 Overlay 消失且 Future 完成状态可观察
+
+## 人工验收
+
+- [ ] 窄屏下十二种 placement 的内容和箭头均可接受
+- [ ] 刘海屏、圆角屏和底部安全区内不裁切
+- [ ] 键盘弹出后底部 Popover 不被遮挡
+- [x] Widget 测试确认 contentWidget 内部菜单项可点击并更新状态
+- [x] Widget 测试确认列表锚点移除时 Popover 自动关闭且 Future 完成
+- [ ] 目标设备页面跳转时 Popover 自动关闭且无视觉残留
+
+## 未覆盖项与后续工作
+
+- 锚点 Element unmounted 后会通过私有生命周期守卫复用幂等 dismiss，自动移除 OverlayEntry、清理监听器并完成 showPopover Future；已由 Widget 测试覆盖。
+- placement 仅做同轴反向翻转，不会在纵向和横向之间跨轴选择。
+- 超长文本在 maxHeight 下的滚动、裁切或省略策略尚未形成公共契约，本次不扩展。
+- 目标设备人工验收尚未执行，因此本 Spec 暂不标记为完全关闭。

--- a/specs/003-popover-contract-hardening/plan.md
+++ b/specs/003-popover-contract-hardening/plan.md
@@ -1,0 +1,50 @@
+# 实施方案
+
+## 技术方案
+
+- 在 TPopoverWidget 的实际气泡内容区域按需包装 GestureDetector，仅当 onTap 或 onLongTap 存在时创建手势识别器，避免覆盖整个 root Overlay。
+- 保留 colorScheme 的文本色和语义背景 token 解析，再以 TPopoverThemeData.backgroundColor 覆盖最终背景色，使容器和箭头共用同一颜色来源。
+- 将文本测量拆分为自然尺寸、显式尺寸和主题上下限：显式 width/height 保持固定；minWidth/maxWidth/maxHeight 只约束文本自然尺寸。
+- TPopover.showPopover 不再把文本模式的 theme.minWidth/theme.maxHeight预先转成固定 width/height；contentWidget 模式保留现有确定尺寸兼容路径。
+- 使用 MediaQuery.size、padding 和 viewInsets 计算可用 viewport；优先将空间不足的 placement 同轴翻转，两侧都不足时再把包含箭头的最终外框 clamp 到可用范围。
+- 根据 clamp 后的气泡位置与锚点中心补偿箭头位移，并用圆角半径加箭头尺寸限制边缘安全区。
+- 仅对有非零 RenderBox 的真实锚点执行 viewport clamp；无 RenderBox 的直接 Widget 用法保留原有定位兼容性。
+- 在 build 阶段检测 unmounted 锚点并停止绘制，同时由 t_popover.dart 内部的私有生命周期守卫在 frame 结束后检查锚点状态；锚点失效时接入 TPopover.showPopover 的幂等 dismiss 路径，确保 OverlayEntry、监听器和 Future 一并清理。
+
+## 影响范围
+
+| 范围 | 文件或模块 | 影响 |
+| --- | --- | --- |
+| 组件入口 | tdesign-component/lib/src/components/popover/t_popover.dart | 区分文本与 contentWidget 的主题尺寸传递 |
+| 组件布局 | tdesign-component/lib/src/components/popover/t_popover_widget.dart | 事件、主题、尺寸、viewport 和锚点状态 |
+| 组件主题 | tdesign-component/lib/src/components/popover/t_popover_theme_data.dart | 不改签名，落实 backgroundColor/maxHeight 既有语义 |
+| 测试 | tdesign-component/test/components/popover/ | 增加公共 API 和边界回归，保留 Golden |
+| 关联测试 | tdesign-component/test/components/popup/ | 验证 Overlay 和 Theme 没有回归 |
+| 示例 | tdesign-component/example/lib/page/t_popover_page.dart | 增加真实可操作的事件、主题尺寸、边界、键盘和生命周期场景 |
+| 示例测试与代码片段 | tdesign-component/example/test/popover_page_test.dart、example/assets/code/popover.*.txt | 自动验证 Demo 行为并同步代码查看器 |
+| 文档 | 本 Spec、生成 API 文档 | 当前签名未变化，无需手工改生成文档 |
+
+## API 变化
+
+- 不新增、不删除公共参数或类型。
+- 修复既有 onTap、onLongTap、backgroundColor、minWidth、maxWidth、maxHeight 的运行时语义。
+- 回调不会自动关闭 Popover，避免引入未声明的行为变化。
+
+## 风险与取舍
+
+- 自动翻转只发生在同轴反方向能够完整容纳气泡时；两侧都不足时保留调用方请求方向并优先保证内容可见。
+- backgroundColor 覆盖语义背景 token 后，调用方需要自行保证与语义文本色的对比度；本次没有新增 textColor API。
+- maxHeight 对超长文本只限制外框高度，若未来需要滚动或省略策略，应单独定义 overflow 契约。
+- 生命周期守卫只在已有 frame 上执行检查，不主动制造持续动画帧；锚点销毁发生在布局 frame 内，随后通过同一 dismiss 路径完成回收。
+- contentWidget 依赖确定尺寸是现有首帧定位限制，本次不扩大到动态测量，避免引入闪烁和二次定位。
+
+## 验证策略
+
+- Widget 测试覆盖回调、主题背景色、maxHeight、默认宽度、外部关闭、滚动、同轴翻转、clamp 和箭头补偿。
+- Example Widget 测试操作真实 Demo，覆盖事件、自定义内容、主题尺寸、窄屏、键盘和锚点销毁。
+- Golden 测试覆盖 light/dark Overlay 视觉基线。
+- 关联 Popup 测试覆盖 Overlay、主题扩展和尺寸行为没有回归。
+- 运行 flutter analyze lib/src/components/popover test/components/popover。
+- 运行 scripts/check-flutter-component-contracts.mjs 和 git diff --check。
+- 运行示例代码生成器及 `--check`，保证代码查看器与 Demo 源码同步。
+- 人工验收窄屏、安全区、键盘、四边 placement、contentWidget 内部交互和页面跳转销毁锚点。

--- a/specs/003-popover-contract-hardening/spec.md
+++ b/specs/003-popover-contract-hardening/spec.md
@@ -1,0 +1,117 @@
+# TPopover：交互、主题、尺寸与浮层边界契约补强
+
+## 元信息
+
+- 记录基线：develop@541f76435e0a492f9f392fe98f72e72167b24516
+- 影响组件：TPopover、TPopoverWidget、TPopoverThemeData
+- 状态：实现、Demo 与自动化验收完成，目标设备人工验收待执行
+
+## 背景
+
+TPopover 已公开点击、长按、主题背景色、最小/最大尺寸和十二种 placement，但原实现存在公开参数未执行、主题字段未消费、最大高度被当作固定高度以及边缘位置越出可用视口的问题。现有测试主要验证“能够渲染”，没有验证这些 API 的实际效果，因此测试全绿仍可能留下运行时契约缺口。
+
+此外，Popover 使用 root Overlay 并持有触发节点的 BuildContext。触发节点在浮层展示期间销毁时，组件不能继续使用失效坐标，也不能永久保留 OverlayEntry、滚动监听或未完成的 Future。
+
+## 目标
+
+- 使 onTap、onLongTap 与公开文档一致，点击气泡内容时各自准确触发。
+- 使 TPopoverThemeData.backgroundColor 真正控制气泡和箭头背景色。
+- 明确 width、height、minWidth、maxWidth、maxHeight 的尺寸语义。
+- 在有效锚点场景中约束 Popover 到安全区、键盘和 viewport 可用范围内。
+- placement 指定方向空间不足而反方向充足时，自动翻转到同轴对应方向。
+- 两侧空间都不足时才平移到 viewport 内，并补偿箭头使其继续指向锚点。
+- 保持外部点击关闭、滚动关闭和底层滚动的既有行为。
+- 触发节点销毁后隐藏并最终回收 Overlay，完成 showPopover 返回的 Future。
+- 用聚焦 Widget/Golden 测试覆盖上述公共行为。
+- 用可操作 Demo 覆盖事件、主题尺寸、窄屏边界、键盘和锚点销毁场景。
+
+## 非目标
+
+- 不新增 Controller、handle 或新的公开关闭 API。
+- 不改变十二种 TPopoverPlacement 的枚举和方向含义。
+- 不改变 contentWidget 必须具有确定外框尺寸的契约。
+- 不重构 Popup、DropdownMenu 或其他 Overlay 组件。
+
+## 范围
+
+### 涉及
+
+- tdesign-component/lib/src/components/popover/t_popover.dart
+- tdesign-component/lib/src/components/popover/t_popover_widget.dart
+- tdesign-component/lib/src/components/popover/t_popover_theme_data.dart
+- tdesign-component/test/components/popover/t_popover_test.dart
+- tdesign-component/test/components/popover/t_popover_golden_test.dart
+- tdesign-component/example/lib/page/t_popover_page.dart
+- tdesign-component/example/test/popover_page_test.dart
+- tdesign-component/example/assets/code/popover.*.txt
+- Popover 与 Popup 主题、Overlay 的直接关联测试。
+
+### 不涉及
+
+- TPopover 公共参数增删。
+- Example 页面视觉重做。
+- 站点组件 README 的手工维护；API Markdown 仍由生成链负责。
+- 自动 placement 翻转与锚点跟随动画。
+
+## 行为契约
+
+### 内容与事件
+
+- content 和 contentWidget 沿用现有可选参数；contentWidget 使用时必须提供确定的 width、height，或由现有组件主题提供对应确定尺寸。
+- 配置 onTap 后，点击气泡实际内容区域调用一次回调，并传入当前 content。
+- 配置 onLongTap 后，长按气泡实际内容区域调用一次回调，并传入当前 content。
+- 未配置回调时不创建会吞掉事件的透明手势区域，外部点击和底层滚动行为保持不变。
+- 回调只负责通知，不隐式关闭 Popover；关闭仍由外部点击、滚动、返回键或生命周期路径决定。
+
+### 主题优先级
+
+- 实例显式参数优先于 TPopoverThemeData，TPopoverThemeData 优先于 TDesign token 兜底。
+- colorScheme 决定默认文本色和语义背景 token。
+- TPopoverThemeData.backgroundColor 非空时覆盖语义背景 token，并同时应用于气泡容器和箭头。
+- barrierColor、padding、borderRadius、arrowSize、showArrow、offset 和 boxShadow 保持现有主题解析行为。
+- 主题读取发生在 inherited dependencies 可用的生命周期阶段，不在 initState 中建立 Theme 依赖。
+
+### 尺寸
+
+- 实例 width、height 表示包含 padding 的确定外框尺寸。
+- 文本内容未显式指定 width 时，minWidth 是宽度下限，maxWidth 是宽度上限；默认 maxWidth 为 300。
+- maxHeight 是文本气泡外框的最大高度，不得把短文本强制撑到 maxHeight。
+- contentWidget 继续使用确定宽高进行首帧定位；现有主题尺寸兼容路径不在本次删除。
+- padding 大于尺寸约束时不得产生负的文本测量宽度或布局异常。
+
+### 定位与可用视口
+
+- top/topLeft/topRight 上方空间不足且下方充足时，分别翻转为 bottom/bottomLeft/bottomRight；bottom 系列反向规则对称。
+- left/leftTop/leftBottom 与 right/rightTop/rightBottom 使用同样的同轴反向规则。
+- 请求方向和反方向都不足时保留请求方向，再对最终外框执行 viewport clamp。
+- clamp 后箭头沿气泡边缘移动以继续指向锚点；箭头中心不得进入圆角与箭头尺寸构成的边缘安全区。
+- 锚点具有有效、非零 RenderBox 时，最终位置约束在 MediaQuery 安全区内。
+- 底部边界同时考虑系统安全区和 viewInsets.bottom，避免键盘遮挡。
+- 横向 placement 的总宽度、纵向 placement 的总高度包含箭头尺寸。
+- 无有效 RenderBox 但上下文仍存活时保留既有兼容定位，不因边界修复改变直接构造 TPopoverWidget 的行为。
+- 锚点 Element 已 unmounted 时不得继续在 (0, 0) 绘制气泡。
+
+### 关闭与生命周期
+
+- closeOnClickOutside 为 true 时，点击气泡外部关闭并完成 showPopover Future。
+- closeOnScroll 为 true 时，祖先滚动和外部指针滚动关闭气泡；底层滚动仍可发生。
+- closeOnScroll 为 false 时，滚动不关闭气泡，保持现有行为。
+- 页面返回或 LocalHistoryEntry 移除时清理 OverlayEntry、滚动监听并完成 Future。
+- 锚点销毁时应主动执行同一清理路径，而不只是隐藏内容；清理必须幂等。
+
+## 验收标准
+
+- [x] onTap、onLongTap 可触发且传入 content。
+- [x] 未配置回调时不阻断外部点击关闭和底层滚动。
+- [x] backgroundColor 同时控制容器和箭头的背景色来源。
+- [x] 短文本在设置 maxHeight 后保持自然高度。
+- [x] 文本宽度遵循 minWidth、maxWidth 和默认 300 上限。
+- [x] 右下角有效锚点的 Popover 不越出可用视口。
+- [x] top/bottom 与 left/right 系列在请求方向空间不足时同轴翻转。
+- [x] 两侧空间都不足时执行 clamp，箭头补偿后仍受圆角安全区约束。
+- [x] 锚点 unmounted 后不在左上角继续绘制。
+- [x] 锚点 unmounted 后 OverlayEntry、监听器和 Future 被主动清理。
+- [x] Popover、Golden、关联 Popup/主题测试通过。
+- [x] Demo 可直接观察事件回调、自定义内容、主题尺寸、四角边界、键盘和锚点销毁行为。
+- [x] Demo Widget 测试覆盖交互、几何边界与生命周期 Future 完成。
+- [x] flutter analyze、组件文档契约检查和 git diff --check 通过。

--- a/specs/003-popover-contract-hardening/tasks.md
+++ b/specs/003-popover-contract-hardening/tasks.md
@@ -1,0 +1,18 @@
+# 实施任务
+
+- [x] 明确回调、主题、尺寸、定位和生命周期行为边界
+- [x] 绑定 onTap、onLongTap，并限制手势命中区域
+- [x] 落实 TPopoverThemeData.backgroundColor
+- [x] 修复 minWidth、maxWidth、maxHeight 的文本尺寸语义
+- [x] 增加安全区、键盘和 viewport 边界约束
+- [x] 避免锚点 unmounted 后在左上角继续绘制
+- [x] 补充背景色、回调、maxHeight 和右下角定位测试
+- [x] 运行 Popover、Golden、关联 Popup/主题测试
+- [x] 运行静态分析、组件文档契约检查和 diff 检查
+- [x] 将锚点销毁接入幂等 dismiss，主动清理 OverlayEntry、监听器并完成 Future
+- [x] 增加事件、自定义内容、主题尺寸、窄屏、键盘和锚点销毁 Demo
+- [x] 增加 Demo Widget 测试并同步生成代码片段
+- [x] 增加 placement 同轴自动翻转与双侧不足时的箭头补偿
+- [x] 补充自动翻转、viewport clamp 和圆角安全区回归测试
+- [ ] 在目标设备完成窄屏、键盘、四边 placement 和 contentWidget 交互人工验收
+- [ ] 完成最终 Review 后关闭 Spec

--- a/tdesign-component/example/assets/code/popover._buildBoundaryPopover.txt
+++ b/tdesign-component/example/assets/code/popover._buildBoundaryPopover.txt
@@ -1,0 +1,62 @@
+Widget _buildBoundaryPopover(BuildContext context) {
+    Widget buildTrigger({
+      required Alignment alignment,
+      required String label,
+      required TPopoverPlacement placement,
+    }) {
+      return Align(
+        alignment: alignment,
+        child: Builder(
+          builder: (popoverContext) {
+            return TButton(
+              key: Key('popover-boundary-$label'),
+              size: TButtonSize.small,
+              variant: TButtonVariant.outline,
+              colorScheme: TButtonColorScheme.primary,
+              onPressed: () {
+                TPopover.showPopover(
+                  context: popoverContext,
+                  content: '$label边界内容',
+                  placement: placement,
+                );
+              },
+              child: Text(label),
+            );
+          },
+        ),
+      );
+    }
+
+    return Container(
+      key: const Key('popover-boundary-area'),
+      height: 180,
+      decoration: BoxDecoration(
+        border: Border.all(color: context.tTheme.grayColor4),
+        borderRadius: BorderRadius.circular(context.tTheme.radiusDefault),
+      ),
+      child: Stack(
+        children: [
+          buildTrigger(
+            alignment: Alignment.topLeft,
+            label: '左上',
+            placement: TPopoverPlacement.topLeft,
+          ),
+          buildTrigger(
+            alignment: Alignment.topRight,
+            label: '右上',
+            placement: TPopoverPlacement.topRight,
+          ),
+          buildTrigger(
+            alignment: Alignment.bottomLeft,
+            label: '左下',
+            placement: TPopoverPlacement.bottomLeft,
+          ),
+          buildTrigger(
+            alignment: Alignment.bottomRight,
+            label: '右下',
+            placement: TPopoverPlacement.bottomRight,
+          ),
+        ],
+      ),
+    );
+  }

--- a/tdesign-component/example/assets/code/popover._buildDarkPopover.txt
+++ b/tdesign-component/example/assets/code/popover._buildDarkPopover.txt
@@ -10,10 +10,7 @@ Widget _buildDarkPopover(BuildContext context) {
             variant: TButtonVariant.outline,
             colorScheme: TButtonColorScheme.primary,
             onPressed: () {
-              TPopover.showPopover(
-                context: popoverContext,
-                content: '弹出气泡内容',
-              );
+              TPopover.showPopover(context: popoverContext, content: '弹出气泡内容');
             },
           );
         },

--- a/tdesign-component/example/assets/code/popover._buildEventPopover.txt
+++ b/tdesign-component/example/assets/code/popover._buildEventPopover.txt
@@ -1,0 +1,32 @@
+Widget _buildEventPopover(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        LayoutBuilder(
+          builder: (popoverContext, constraints) {
+            return TButton(
+              key: const Key('popover-event-trigger'),
+              variant: TButtonVariant.outline,
+              colorScheme: TButtonColorScheme.primary,
+              onPressed: () {
+                TPopover.showPopover(
+                  context: popoverContext,
+                  content: '点击或长按我',
+                  placement: TPopoverPlacement.bottom,
+                  onTap: (content) {
+                    setState(() => _eventStatus = 'onTap：$content');
+                  },
+                  onLongTap: (content) {
+                    setState(() => _eventStatus = 'onLongTap：$content');
+                  },
+                );
+              },
+              child: const Text('事件回调'),
+            );
+          },
+        ),
+        const SizedBox(height: 8),
+        TText(_eventStatus, key: const Key('popover-event-status')),
+      ],
+    );
+  }

--- a/tdesign-component/example/assets/code/popover._buildInteractiveContentPopover.txt
+++ b/tdesign-component/example/assets/code/popover._buildInteractiveContentPopover.txt
@@ -1,0 +1,54 @@
+Widget _buildInteractiveContentPopover(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        LayoutBuilder(
+          builder: (popoverContext, constraints) {
+            return TButton(
+              key: const Key('popover-interactive-trigger'),
+              variant: TButtonVariant.outline,
+              colorScheme: TButtonColorScheme.primary,
+              onPressed: () {
+                TPopover.showPopover(
+                  context: popoverContext,
+                  width: 180,
+                  height: 104,
+                  padding: EdgeInsets.zero,
+                  placement: TPopoverPlacement.bottom,
+                  contentWidget: Column(
+                    children: [
+                      Expanded(
+                        child: GestureDetector(
+                          key: const Key('popover-menu-复制'),
+                          behavior: HitTestBehavior.opaque,
+                          onTap: () =>
+                              setState(() => _customContentStatus = '已选择复制'),
+                          child: const Center(child: TText('复制')),
+                        ),
+                      ),
+                      const TDivider(),
+                      Expanded(
+                        child: GestureDetector(
+                          key: const Key('popover-menu-分享'),
+                          behavior: HitTestBehavior.opaque,
+                          onTap: () =>
+                              setState(() => _customContentStatus = '已选择分享'),
+                          child: const Center(child: TText('分享')),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+              child: const Text('打开操作菜单'),
+            );
+          },
+        ),
+        const SizedBox(height: 8),
+        TText(
+          _customContentStatus,
+          key: const Key('popover-interactive-status'),
+        ),
+      ],
+    );
+  }

--- a/tdesign-component/example/assets/code/popover._buildKeyboardPopover.txt
+++ b/tdesign-component/example/assets/code/popover._buildKeyboardPopover.txt
@@ -1,0 +1,35 @@
+Widget _buildKeyboardPopover(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const TextField(
+          key: Key('popover-keyboard-input'),
+          decoration: InputDecoration(
+            border: OutlineInputBorder(),
+            hintText: '先点击输入框唤起键盘',
+          ),
+        ),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerRight,
+          child: Builder(
+            builder: (popoverContext) {
+              return TButton(
+                key: const Key('popover-keyboard-trigger'),
+                variant: TButtonVariant.outline,
+                colorScheme: TButtonColorScheme.primary,
+                onPressed: () {
+                  TPopover.showPopover(
+                    context: popoverContext,
+                    content: '键盘弹出时保持在可用区域',
+                    placement: TPopoverPlacement.bottomRight,
+                  );
+                },
+                child: const Text('键盘上方显示'),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }

--- a/tdesign-component/example/assets/code/popover._buildLifecyclePopover.txt
+++ b/tdesign-component/example/assets/code/popover._buildLifecyclePopover.txt
@@ -1,0 +1,58 @@
+Widget _buildLifecyclePopover(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          spacing: 12,
+          runSpacing: 8,
+          children: [
+            if (_showLifecycleAnchor)
+              Builder(
+                builder: (popoverContext) {
+                  return TButton(
+                    key: const Key('popover-lifecycle-anchor'),
+                    variant: TButtonVariant.outline,
+                    colorScheme: TButtonColorScheme.primary,
+                    onPressed: () {
+                      setState(() => _lifecycleStatus = 'Popover 展示中');
+                      unawaited(
+                        TPopover.showPopover(
+                          context: popoverContext,
+                          content: '移除锚点后自动关闭',
+                          placement: TPopoverPlacement.bottom,
+                          closeOnClickOutside: false,
+                          closeOnScroll: false,
+                        ).then((_) {
+                          if (mounted) {
+                            setState(
+                              () => _lifecycleStatus = 'Future 已完成，Overlay 已清理',
+                            );
+                          }
+                        }),
+                      );
+                    },
+                    child: const Text('打开生命周期气泡'),
+                  );
+                },
+              ),
+            TButton(
+              key: const Key('popover-lifecycle-toggle'),
+              variant: TButtonVariant.outline,
+              colorScheme: TButtonColorScheme.primary,
+              onPressed: () {
+                setState(() {
+                  _showLifecycleAnchor = !_showLifecycleAnchor;
+                  if (_showLifecycleAnchor) {
+                    _lifecycleStatus = '锚点已恢复';
+                  }
+                });
+              },
+              child: Text(_showLifecycleAnchor ? '移除锚点' : '恢复锚点'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        TText(_lifecycleStatus, key: const Key('popover-lifecycle-status')),
+      ],
+    );
+  }

--- a/tdesign-component/example/assets/code/popover._buildNCustomPopover.txt
+++ b/tdesign-component/example/assets/code/popover._buildNCustomPopover.txt
@@ -1,8 +1,9 @@
 Widget _buildNCustomPopover(BuildContext context) {
     var textStyle = TextStyle(
-        color: theme == TPopoverColorScheme.light
-            ? context.tTheme.fontGyColor1
-            : context.tTheme.fontWhColor1);
+      color: theme == TPopoverColorScheme.light
+          ? context.tTheme.fontGyColor1
+          : context.tTheme.fontWhColor1,
+    );
     return LayoutBuilder(
       builder: (popoverContext, constrains) {
         return TButton(
@@ -14,26 +15,32 @@ Widget _buildNCustomPopover(BuildContext context) {
               context: popoverContext,
               padding: const EdgeInsets.all(0),
               colorScheme: theme,
-              // contentWidget 模式下必须指定 width 和 height（组件 initState 断言要求）
+              // contentWidget 模式下必须指定确定的 width 和 height。
               width: 150,
               height: 146,
               contentWidget: Column(
                 children: [
                   Container(
                     padding: const EdgeInsets.symmetric(
-                        vertical: 12, horizontal: 24),
+                      vertical: 12,
+                      horizontal: 24,
+                    ),
                     child: TText('选项1', style: textStyle),
                   ),
                   const TDivider(),
                   Container(
                     padding: const EdgeInsets.symmetric(
-                        vertical: 12, horizontal: 24),
+                      vertical: 12,
+                      horizontal: 24,
+                    ),
                     child: TText('选项2', style: textStyle),
                   ),
                   const TDivider(),
                   Container(
                     padding: const EdgeInsets.symmetric(
-                        vertical: 12, horizontal: 24),
+                      vertical: 12,
+                      horizontal: 24,
+                    ),
                     child: TText('选项3', style: textStyle),
                   ),
                 ],

--- a/tdesign-component/example/assets/code/popover._buildNoArrowPopover.txt
+++ b/tdesign-component/example/assets/code/popover._buildNoArrowPopover.txt
@@ -8,10 +8,11 @@ Widget _buildNoArrowPopover(BuildContext context) {
           colorScheme: TButtonColorScheme.primary,
           onPressed: () {
             TPopover.showPopover(
-                context: popoverContext,
-                content: '弹出气泡内容',
-                showArrow: false,
-                colorScheme: theme);
+              context: popoverContext,
+              content: '弹出气泡内容',
+              showArrow: false,
+              colorScheme: theme,
+            );
           },
         );
       },

--- a/tdesign-component/example/assets/code/popover._buildPopover.txt
+++ b/tdesign-component/example/assets/code/popover._buildPopover.txt
@@ -10,7 +10,10 @@ Widget _buildPopover(BuildContext context) {
             colorScheme: TButtonColorScheme.primary,
             onPressed: () {
               TPopover.showPopover(
-                  context: popoverContext, content: '弹出气泡内容', colorScheme: theme);
+                context: popoverContext,
+                content: '弹出气泡内容',
+                colorScheme: theme,
+              );
             },
           );
         },

--- a/tdesign-component/example/assets/code/popover._buildThemeSizePopover.txt
+++ b/tdesign-component/example/assets/code/popover._buildThemeSizePopover.txt
@@ -1,0 +1,53 @@
+Widget _buildThemeSizePopover(BuildContext context) {
+    final popoverTheme = Theme.of(context).mergeExtension(
+      const TPopoverThemeData(
+        backgroundColor: Color(0xFF5E3BB7),
+        minWidth: 120,
+        maxWidth: 180,
+        maxHeight: 120,
+      ),
+    );
+    return Theme(
+      data: popoverTheme,
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 8,
+        children: [
+          Builder(
+            builder: (popoverContext) {
+              return TButton(
+                key: const Key('popover-theme-short-trigger'),
+                variant: TButtonVariant.outline,
+                colorScheme: TButtonColorScheme.primary,
+                onPressed: () {
+                  TPopover.showPopover(
+                    context: popoverContext,
+                    content: '短文本',
+                    placement: TPopoverPlacement.bottom,
+                  );
+                },
+                child: const Text('主题背景与最小宽度'),
+              );
+            },
+          ),
+          Builder(
+            builder: (popoverContext) {
+              return TButton(
+                key: const Key('popover-theme-long-trigger'),
+                variant: TButtonVariant.outline,
+                colorScheme: TButtonColorScheme.primary,
+                onPressed: () {
+                  TPopover.showPopover(
+                    context: popoverContext,
+                    content: '这是一段用于验证最大宽度和自然换行的较长气泡文本',
+                    placement: TPopoverPlacement.bottom,
+                  );
+                },
+                child: const Text('最大宽度与自然换行'),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }

--- a/tdesign-component/example/lib/page/t_popover_page.dart
+++ b/tdesign-component/example/lib/page/t_popover_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:tdesign_flutter/tdesign_flutter.dart';
 
@@ -13,11 +15,18 @@ class TPopoverPage extends StatefulWidget {
 
 class _TPopoverPage extends State<TPopoverPage> {
   TPopoverColorScheme theme = TPopoverColorScheme.light;
+  String _eventStatus = '点击或长按气泡后查看结果';
+  String _customContentStatus = '尚未选择菜单项';
+  String _lifecycleStatus = '尚未打开生命周期气泡';
+  bool _showLifecycleAnchor = true;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
       setState(() {
         theme = Theme.of(context).brightness == Brightness.dark
             ? TPopoverColorScheme.light
@@ -41,157 +50,166 @@ class _TPopoverPage extends State<TPopoverPage> {
             ExampleItem(desc: '自定义内容弹出气泡', builder: _buildNCustomPopover),
           ],
         ),
-        ExampleModule(title: '组件样式', children: [
-          ExampleItem(
-            ignoreCode: true,
-            builder: (context) {
-              return Container(
-                alignment: Alignment.topLeft,
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                child: Column(
-                  children: [
-                    Flex(
-                      direction: Axis.horizontal,
-                      children: [
-                        Expanded(
-                          child: CodeWrapper(builder: _buildDarkPopover),
-                        ),
-                        Expanded(
-                          child: CodeWrapper(builder: _buildLightPopover),
-                        ),
-                        Expanded(
-                          child: CodeWrapper(builder: _buildInfoPopover),
-                        ),
-                      ],
-                    ),
-                    Flex(
-                      direction: Axis.horizontal,
-                      children: [
-                        Expanded(
-                          child: CodeWrapper(builder: _buildSuccessPopover),
-                        ),
-                        Expanded(
-                          child: CodeWrapper(builder: _buildWarningPopover),
-                        ),
-                        Expanded(
-                          child: CodeWrapper(builder: _buildErrorPopover),
-                        ),
-                      ],
-                    )
-                  ],
-                ),
-              );
-            },
-          ),
-          ExampleItem(
-            desc: '顶部弹出气泡',
-            ignoreCode: true,
-            builder: (context) {
-              return Container(
-                alignment: Alignment.topLeft,
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                child: Flex(
-                  direction: Axis.horizontal,
-                  children: [
-                    Expanded(
-                      child: CodeWrapper(builder: _buildTopLeftPopover),
-                    ),
-                    Expanded(
-                      child: CodeWrapper(builder: _buildTopPopover),
-                    ),
-                    Expanded(
-                      child: CodeWrapper(builder: _buildTopRightPopover),
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
-          ExampleItem(
-            desc: '底部弹出气泡',
-            ignoreCode: true,
-            builder: (context) {
-              return Container(
-                alignment: Alignment.topLeft,
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                child: Flex(
-                  direction: Axis.horizontal,
-                  children: [
-                    Expanded(
-                      child: CodeWrapper(builder: _buildBottomLeftPopover),
-                    ),
-                    Expanded(
-                      child: CodeWrapper(builder: _buildBottomPopover),
-                    ),
-                    Expanded(
-                      child: CodeWrapper(builder: _buildBottomRightPopover),
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
-          ExampleItem(
-            desc: '右侧弹出气泡',
-            ignoreCode: true,
-            builder: (context) {
-              return Container(
-                alignment: Alignment.topLeft,
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                child: Flex(
-                  direction: Axis.horizontal,
-                  children: [
-                    Expanded(
-                      child: Column(
+        ExampleModule(
+          title: '组件样式',
+          children: [
+            ExampleItem(
+              ignoreCode: true,
+              builder: (context) {
+                return Container(
+                  alignment: Alignment.topLeft,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Column(
+                    children: [
+                      Flex(
+                        direction: Axis.horizontal,
                         children: [
-                          CodeWrapper(builder: _buildRightTopPopover),
-                          CodeWrapper(builder: _buildRightPopover),
-                          CodeWrapper(builder: _buildRightBottomPopover),
+                          Expanded(
+                            child: CodeWrapper(builder: _buildDarkPopover),
+                          ),
+                          Expanded(
+                            child: CodeWrapper(builder: _buildLightPopover),
+                          ),
+                          Expanded(
+                            child: CodeWrapper(builder: _buildInfoPopover),
+                          ),
                         ],
                       ),
-                    ),
-                    const Expanded(child: SizedBox()),
-                  ],
-                ),
-              );
-            },
-          ),
-          ExampleItem(
-            desc: '左侧弹出气泡',
-            ignoreCode: true,
-            builder: (context) {
-              return Container(
-                alignment: Alignment.topLeft,
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                child: Flex(
-                  direction: Axis.horizontal,
-                  children: [
-                    const Expanded(child: SizedBox()),
-                    Expanded(
-                      child: Column(
+                      Flex(
+                        direction: Axis.horizontal,
                         children: [
-                          CodeWrapper(builder: _buildLeftTopPopover),
-                          CodeWrapper(builder: _buildLeftPopover),
-                          CodeWrapper(builder: _buildLeftBottomPopover),
+                          Expanded(
+                            child: CodeWrapper(builder: _buildSuccessPopover),
+                          ),
+                          Expanded(
+                            child: CodeWrapper(builder: _buildWarningPopover),
+                          ),
+                          Expanded(
+                            child: CodeWrapper(builder: _buildErrorPopover),
+                          ),
                         ],
                       ),
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
-        ])
+                    ],
+                  ),
+                );
+              },
+            ),
+            ExampleItem(
+              desc: '顶部弹出气泡',
+              ignoreCode: true,
+              builder: (context) {
+                return Container(
+                  alignment: Alignment.topLeft,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Flex(
+                    direction: Axis.horizontal,
+                    children: [
+                      Expanded(
+                        child: CodeWrapper(builder: _buildTopLeftPopover),
+                      ),
+                      Expanded(child: CodeWrapper(builder: _buildTopPopover)),
+                      Expanded(
+                        child: CodeWrapper(builder: _buildTopRightPopover),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            ExampleItem(
+              desc: '底部弹出气泡',
+              ignoreCode: true,
+              builder: (context) {
+                return Container(
+                  alignment: Alignment.topLeft,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Flex(
+                    direction: Axis.horizontal,
+                    children: [
+                      Expanded(
+                        child: CodeWrapper(builder: _buildBottomLeftPopover),
+                      ),
+                      Expanded(
+                        child: CodeWrapper(builder: _buildBottomPopover),
+                      ),
+                      Expanded(
+                        child: CodeWrapper(builder: _buildBottomRightPopover),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            ExampleItem(
+              desc: '右侧弹出气泡',
+              ignoreCode: true,
+              builder: (context) {
+                return Container(
+                  alignment: Alignment.topLeft,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Flex(
+                    direction: Axis.horizontal,
+                    children: [
+                      Expanded(
+                        child: Column(
+                          children: [
+                            CodeWrapper(builder: _buildRightTopPopover),
+                            CodeWrapper(builder: _buildRightPopover),
+                            CodeWrapper(builder: _buildRightBottomPopover),
+                          ],
+                        ),
+                      ),
+                      const Expanded(child: SizedBox()),
+                    ],
+                  ),
+                );
+              },
+            ),
+            ExampleItem(
+              desc: '左侧弹出气泡',
+              ignoreCode: true,
+              builder: (context) {
+                return Container(
+                  alignment: Alignment.topLeft,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Flex(
+                    direction: Axis.horizontal,
+                    children: [
+                      const Expanded(child: SizedBox()),
+                      Expanded(
+                        child: Column(
+                          children: [
+                            CodeWrapper(builder: _buildLeftTopPopover),
+                            CodeWrapper(builder: _buildLeftPopover),
+                            CodeWrapper(builder: _buildLeftBottomPopover),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+        ExampleModule(
+          title: '交互与边界',
+          children: [
+            ExampleItem(desc: '点击与长按回调', builder: _buildEventPopover),
+            ExampleItem(
+              desc: '可交互自定义内容',
+              builder: _buildInteractiveContentPopover,
+            ),
+            ExampleItem(desc: '主题与尺寸约束', builder: _buildThemeSizePopover),
+            ExampleItem(desc: '窄屏四角边界与自动翻转', builder: _buildBoundaryPopover),
+            ExampleItem(desc: '键盘遮挡场景', builder: _buildKeyboardPopover),
+            ExampleItem(desc: '锚点销毁与 Future', builder: _buildLifecyclePopover),
+          ],
+        ),
       ],
       test: [
-        ExampleItem(
-          desc: '显示多行内容',
-          builder: _buildMultiLinePopover,
-        ),
-        ExampleItem(
-          desc: '自定义圆角',
-          builder: _buildCustomRadiusPopover,
-        )
+        ExampleItem(desc: '显示多行内容', builder: _buildMultiLinePopover),
+        ExampleItem(desc: '自定义圆角', builder: _buildCustomRadiusPopover),
       ],
     );
   }
@@ -209,7 +227,10 @@ class _TPopoverPage extends State<TPopoverPage> {
             colorScheme: TButtonColorScheme.primary,
             onPressed: () {
               TPopover.showPopover(
-                  context: popoverContext, content: '弹出气泡内容', colorScheme: theme);
+                context: popoverContext,
+                content: '弹出气泡内容',
+                colorScheme: theme,
+              );
             },
           );
         },
@@ -228,10 +249,11 @@ class _TPopoverPage extends State<TPopoverPage> {
           colorScheme: TButtonColorScheme.primary,
           onPressed: () {
             TPopover.showPopover(
-                context: popoverContext,
-                content: '弹出气泡内容',
-                showArrow: false,
-                colorScheme: theme);
+              context: popoverContext,
+              content: '弹出气泡内容',
+              showArrow: false,
+              colorScheme: theme,
+            );
           },
         );
       },
@@ -241,9 +263,10 @@ class _TPopoverPage extends State<TPopoverPage> {
   @ExampleCode(group: 'popover')
   Widget _buildNCustomPopover(BuildContext context) {
     var textStyle = TextStyle(
-        color: theme == TPopoverColorScheme.light
-            ? context.tTheme.fontGyColor1
-            : context.tTheme.fontWhColor1);
+      color: theme == TPopoverColorScheme.light
+          ? context.tTheme.fontGyColor1
+          : context.tTheme.fontWhColor1,
+    );
     return LayoutBuilder(
       builder: (popoverContext, constrains) {
         return TButton(
@@ -255,26 +278,32 @@ class _TPopoverPage extends State<TPopoverPage> {
               context: popoverContext,
               padding: const EdgeInsets.all(0),
               colorScheme: theme,
-              // contentWidget 模式下必须指定 width 和 height（组件 initState 断言要求）
+              // contentWidget 模式下必须指定确定的 width 和 height。
               width: 150,
               height: 146,
               contentWidget: Column(
                 children: [
                   Container(
                     padding: const EdgeInsets.symmetric(
-                        vertical: 12, horizontal: 24),
+                      vertical: 12,
+                      horizontal: 24,
+                    ),
                     child: TText('选项1', style: textStyle),
                   ),
                   const TDivider(),
                   Container(
                     padding: const EdgeInsets.symmetric(
-                        vertical: 12, horizontal: 24),
+                      vertical: 12,
+                      horizontal: 24,
+                    ),
                     child: TText('选项2', style: textStyle),
                   ),
                   const TDivider(),
                   Container(
                     padding: const EdgeInsets.symmetric(
-                        vertical: 12, horizontal: 24),
+                      vertical: 12,
+                      horizontal: 24,
+                    ),
                     child: TText('选项3', style: textStyle),
                   ),
                 ],
@@ -283,6 +312,312 @@ class _TPopoverPage extends State<TPopoverPage> {
           },
         );
       },
+    );
+  }
+
+  @ExampleCode(group: 'popover')
+  Widget _buildEventPopover(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        LayoutBuilder(
+          builder: (popoverContext, constraints) {
+            return TButton(
+              key: const Key('popover-event-trigger'),
+              variant: TButtonVariant.outline,
+              colorScheme: TButtonColorScheme.primary,
+              onPressed: () {
+                TPopover.showPopover(
+                  context: popoverContext,
+                  content: '点击或长按我',
+                  placement: TPopoverPlacement.bottom,
+                  onTap: (content) {
+                    setState(() => _eventStatus = 'onTap：$content');
+                  },
+                  onLongTap: (content) {
+                    setState(() => _eventStatus = 'onLongTap：$content');
+                  },
+                );
+              },
+              child: const Text('事件回调'),
+            );
+          },
+        ),
+        const SizedBox(height: 8),
+        TText(_eventStatus, key: const Key('popover-event-status')),
+      ],
+    );
+  }
+
+  @ExampleCode(group: 'popover')
+  Widget _buildInteractiveContentPopover(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        LayoutBuilder(
+          builder: (popoverContext, constraints) {
+            return TButton(
+              key: const Key('popover-interactive-trigger'),
+              variant: TButtonVariant.outline,
+              colorScheme: TButtonColorScheme.primary,
+              onPressed: () {
+                TPopover.showPopover(
+                  context: popoverContext,
+                  width: 180,
+                  height: 104,
+                  padding: EdgeInsets.zero,
+                  placement: TPopoverPlacement.bottom,
+                  contentWidget: Column(
+                    children: [
+                      Expanded(
+                        child: GestureDetector(
+                          key: const Key('popover-menu-复制'),
+                          behavior: HitTestBehavior.opaque,
+                          onTap: () =>
+                              setState(() => _customContentStatus = '已选择复制'),
+                          child: const Center(child: TText('复制')),
+                        ),
+                      ),
+                      const TDivider(),
+                      Expanded(
+                        child: GestureDetector(
+                          key: const Key('popover-menu-分享'),
+                          behavior: HitTestBehavior.opaque,
+                          onTap: () =>
+                              setState(() => _customContentStatus = '已选择分享'),
+                          child: const Center(child: TText('分享')),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+              child: const Text('打开操作菜单'),
+            );
+          },
+        ),
+        const SizedBox(height: 8),
+        TText(
+          _customContentStatus,
+          key: const Key('popover-interactive-status'),
+        ),
+      ],
+    );
+  }
+
+  @ExampleCode(group: 'popover')
+  Widget _buildThemeSizePopover(BuildContext context) {
+    final popoverTheme = Theme.of(context).mergeExtension(
+      const TPopoverThemeData(
+        backgroundColor: Color(0xFF5E3BB7),
+        minWidth: 120,
+        maxWidth: 180,
+        maxHeight: 120,
+      ),
+    );
+    return Theme(
+      data: popoverTheme,
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 8,
+        children: [
+          Builder(
+            builder: (popoverContext) {
+              return TButton(
+                key: const Key('popover-theme-short-trigger'),
+                variant: TButtonVariant.outline,
+                colorScheme: TButtonColorScheme.primary,
+                onPressed: () {
+                  TPopover.showPopover(
+                    context: popoverContext,
+                    content: '短文本',
+                    placement: TPopoverPlacement.bottom,
+                  );
+                },
+                child: const Text('主题背景与最小宽度'),
+              );
+            },
+          ),
+          Builder(
+            builder: (popoverContext) {
+              return TButton(
+                key: const Key('popover-theme-long-trigger'),
+                variant: TButtonVariant.outline,
+                colorScheme: TButtonColorScheme.primary,
+                onPressed: () {
+                  TPopover.showPopover(
+                    context: popoverContext,
+                    content: '这是一段用于验证最大宽度和自然换行的较长气泡文本',
+                    placement: TPopoverPlacement.bottom,
+                  );
+                },
+                child: const Text('最大宽度与自然换行'),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  @ExampleCode(group: 'popover')
+  Widget _buildBoundaryPopover(BuildContext context) {
+    Widget buildTrigger({
+      required Alignment alignment,
+      required String label,
+      required TPopoverPlacement placement,
+    }) {
+      return Align(
+        alignment: alignment,
+        child: Builder(
+          builder: (popoverContext) {
+            return TButton(
+              key: Key('popover-boundary-$label'),
+              size: TButtonSize.small,
+              variant: TButtonVariant.outline,
+              colorScheme: TButtonColorScheme.primary,
+              onPressed: () {
+                TPopover.showPopover(
+                  context: popoverContext,
+                  content: '$label边界内容',
+                  placement: placement,
+                );
+              },
+              child: Text(label),
+            );
+          },
+        ),
+      );
+    }
+
+    return Container(
+      key: const Key('popover-boundary-area'),
+      height: 180,
+      decoration: BoxDecoration(
+        border: Border.all(color: context.tTheme.grayColor4),
+        borderRadius: BorderRadius.circular(context.tTheme.radiusDefault),
+      ),
+      child: Stack(
+        children: [
+          buildTrigger(
+            alignment: Alignment.topLeft,
+            label: '左上',
+            placement: TPopoverPlacement.topLeft,
+          ),
+          buildTrigger(
+            alignment: Alignment.topRight,
+            label: '右上',
+            placement: TPopoverPlacement.topRight,
+          ),
+          buildTrigger(
+            alignment: Alignment.bottomLeft,
+            label: '左下',
+            placement: TPopoverPlacement.bottomLeft,
+          ),
+          buildTrigger(
+            alignment: Alignment.bottomRight,
+            label: '右下',
+            placement: TPopoverPlacement.bottomRight,
+          ),
+        ],
+      ),
+    );
+  }
+
+  @ExampleCode(group: 'popover')
+  Widget _buildKeyboardPopover(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const TextField(
+          key: Key('popover-keyboard-input'),
+          decoration: InputDecoration(
+            border: OutlineInputBorder(),
+            hintText: '先点击输入框唤起键盘',
+          ),
+        ),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerRight,
+          child: Builder(
+            builder: (popoverContext) {
+              return TButton(
+                key: const Key('popover-keyboard-trigger'),
+                variant: TButtonVariant.outline,
+                colorScheme: TButtonColorScheme.primary,
+                onPressed: () {
+                  TPopover.showPopover(
+                    context: popoverContext,
+                    content: '键盘弹出时保持在可用区域',
+                    placement: TPopoverPlacement.bottomRight,
+                  );
+                },
+                child: const Text('键盘上方显示'),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  @ExampleCode(group: 'popover')
+  Widget _buildLifecyclePopover(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          spacing: 12,
+          runSpacing: 8,
+          children: [
+            if (_showLifecycleAnchor)
+              Builder(
+                builder: (popoverContext) {
+                  return TButton(
+                    key: const Key('popover-lifecycle-anchor'),
+                    variant: TButtonVariant.outline,
+                    colorScheme: TButtonColorScheme.primary,
+                    onPressed: () {
+                      setState(() => _lifecycleStatus = 'Popover 展示中');
+                      unawaited(
+                        TPopover.showPopover(
+                          context: popoverContext,
+                          content: '移除锚点后自动关闭',
+                          placement: TPopoverPlacement.bottom,
+                          closeOnClickOutside: false,
+                          closeOnScroll: false,
+                        ).then((_) {
+                          if (mounted) {
+                            setState(
+                              () => _lifecycleStatus = 'Future 已完成，Overlay 已清理',
+                            );
+                          }
+                        }),
+                      );
+                    },
+                    child: const Text('打开生命周期气泡'),
+                  );
+                },
+              ),
+            TButton(
+              key: const Key('popover-lifecycle-toggle'),
+              variant: TButtonVariant.outline,
+              colorScheme: TButtonColorScheme.primary,
+              onPressed: () {
+                setState(() {
+                  _showLifecycleAnchor = !_showLifecycleAnchor;
+                  if (_showLifecycleAnchor) {
+                    _lifecycleStatus = '锚点已恢复';
+                  }
+                });
+              },
+              child: Text(_showLifecycleAnchor ? '移除锚点' : '恢复锚点'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        TText(_lifecycleStatus, key: const Key('popover-lifecycle-status')),
+      ],
     );
   }
 
@@ -299,10 +634,7 @@ class _TPopoverPage extends State<TPopoverPage> {
             variant: TButtonVariant.outline,
             colorScheme: TButtonColorScheme.primary,
             onPressed: () {
-              TPopover.showPopover(
-                context: popoverContext,
-                content: '弹出气泡内容',
-              );
+              TPopover.showPopover(context: popoverContext, content: '弹出气泡内容');
             },
           );
         },

--- a/tdesign-component/example/test/popover_page_test.dart
+++ b/tdesign-component/example/test/popover_page_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tdesign_flutter/tdesign_flutter.dart';
+import 'package:tdesign_flutter_example/page/t_popover_page.dart';
+import 'package:tdesign_flutter_example/provider/theme_mode_provider.dart';
+
+void main() {
+  Widget buildPage() {
+    return ChangeNotifierProvider(
+      create: (_) => ThemeModeProvider(),
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: TThemeBuilder.light(TThemeData.defaultData()),
+        home: const TPopoverPage(),
+      ),
+    );
+  }
+
+  void configurePhone(WidgetTester tester, {Size size = const Size(375, 812)}) {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetViewInsets);
+  }
+
+  Future<void> showPage(WidgetTester tester) async {
+    await tester.pumpWidget(buildPage());
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> reveal(WidgetTester tester, Finder finder) async {
+    await tester.scrollUntilVisible(
+      finder,
+      400,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('事件回调和自定义内容展示真实状态变化', (tester) async {
+    configurePhone(tester);
+    await showPage(tester);
+
+    final eventTrigger = find.byKey(const Key('popover-event-trigger'));
+    await reveal(tester, eventTrigger);
+    await tester.tap(eventTrigger);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('点击或长按我'));
+    await tester.pump();
+    expect(find.text('onTap：点击或长按我'), findsOneWidget);
+
+    await tester.longPress(find.text('点击或长按我'));
+    await tester.pump();
+    expect(find.text('onLongTap：点击或长按我'), findsOneWidget);
+
+    await tester.tapAt(const Offset(8, 80));
+    await tester.pumpAndSettle();
+    final menuTrigger = find.byKey(const Key('popover-interactive-trigger'));
+    await reveal(tester, menuTrigger);
+    await tester.tap(menuTrigger);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('popover-menu-复制')));
+    await tester.pump();
+    expect(find.text('已选择复制'), findsOneWidget);
+  });
+
+  testWidgets('主题背景与尺寸约束在 Demo 中可观察', (tester) async {
+    configurePhone(tester);
+    await showPage(tester);
+
+    final trigger = find.byKey(const Key('popover-theme-short-trigger'));
+    await reveal(tester, trigger);
+    await tester.tap(trigger);
+    await tester.pumpAndSettle();
+
+    final containerFinder = find
+        .descendant(
+          of: find.byType(TPopoverWidget),
+          matching: find.byWidgetPredicate(
+            (widget) =>
+                widget is Container && widget.decoration is BoxDecoration,
+          ),
+        )
+        .first;
+    final container = tester.widget<Container>(containerFinder);
+    expect(
+      (container.decoration! as BoxDecoration).color,
+      const Color(0xFF5E3BB7),
+    );
+    final size = tester.getSize(containerFinder);
+    expect(size.width, greaterThanOrEqualTo(120));
+    expect(size.width, lessThanOrEqualTo(180));
+    expect(size.height, lessThan(120));
+  });
+
+  testWidgets('窄屏右下角和键盘场景保持在可用视口内', (tester) async {
+    configurePhone(tester, size: const Size(320, 640));
+    await showPage(tester);
+
+    final boundaryTrigger = find.byKey(const Key('popover-boundary-右下'));
+    await reveal(tester, boundaryTrigger);
+    await tester.tap(boundaryTrigger);
+    await tester.pumpAndSettle();
+    var rect = tester.getRect(find.text('右下边界内容'));
+    expect(rect.left, greaterThanOrEqualTo(0));
+    expect(rect.right, lessThanOrEqualTo(320));
+    expect(rect.bottom, lessThanOrEqualTo(640));
+
+    await tester.tapAt(const Offset(8, 80));
+    await tester.pumpAndSettle();
+    final input = find.byKey(const Key('popover-keyboard-input'));
+    await reveal(tester, input);
+    await tester.tap(input);
+    tester.view.viewInsets = const FakeViewPadding(bottom: 240);
+    tester.binding.handleMetricsChanged();
+    await tester.pumpAndSettle();
+
+    final keyboardTrigger = find.byKey(const Key('popover-keyboard-trigger'));
+    await reveal(tester, keyboardTrigger);
+    await tester.tap(keyboardTrigger);
+    await tester.pumpAndSettle();
+    rect = tester.getRect(find.text('键盘弹出时保持在可用区域'));
+    expect(rect.bottom, lessThanOrEqualTo(400));
+  });
+
+  testWidgets('移除 Demo 锚点后展示 Future 完成状态', (tester) async {
+    configurePhone(tester);
+    await showPage(tester);
+
+    final anchor = find.byKey(const Key('popover-lifecycle-anchor'));
+    await reveal(tester, anchor);
+    await tester.tap(anchor);
+    await tester.pump();
+    expect(find.text('移除锚点后自动关闭'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('popover-lifecycle-toggle')));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('移除锚点后自动关闭'), findsNothing);
+    expect(find.text('Future 已完成，Overlay 已清理'), findsOneWidget);
+  });
+}

--- a/tdesign-component/lib/src/components/popover/t_popover.dart
+++ b/tdesign-component/lib/src/components/popover/t_popover.dart
@@ -5,6 +5,64 @@ import 'package:flutter/material.dart';
 import 't_popover_theme_data.dart';
 import 't_popover_widget.dart';
 
+class _PopoverAnchorLifecycle extends StatefulWidget {
+  const _PopoverAnchorLifecycle({
+    required this.anchorContext,
+    required this.onAnchorUnmounted,
+    required this.child,
+  });
+
+  final BuildContext anchorContext;
+  final VoidCallback onAnchorUnmounted;
+  final Widget child;
+
+  @override
+  State<_PopoverAnchorLifecycle> createState() =>
+      _PopoverAnchorLifecycleState();
+}
+
+class _PopoverAnchorLifecycleState extends State<_PopoverAnchorLifecycle> {
+  var _checkScheduled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleAnchorCheck();
+  }
+
+  @override
+  void didUpdateWidget(_PopoverAnchorLifecycle oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _scheduleAnchorCheck();
+  }
+
+  void _scheduleAnchorCheck() {
+    if (_checkScheduled) {
+      return;
+    }
+    _checkScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback(_checkAnchor);
+  }
+
+  void _checkAnchor(Duration _) {
+    _checkScheduled = false;
+    if (!mounted) {
+      return;
+    }
+    if (widget.anchorContext case final Element element when !element.mounted) {
+      widget.onAnchorUnmounted();
+      return;
+    }
+    _scheduleAnchorCheck();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _scheduleAnchorCheck();
+    return widget.child;
+  }
+}
+
 /// 气泡弹层
 ///
 /// 通过 [showPopover] 静态方法弹出，支持 12 个方向定位和箭头。
@@ -148,8 +206,8 @@ class TPopover {
             showArrow: showArrow ?? theme.showArrow,
             arrowSize: arrowSize ?? theme.arrowSize,
             padding: padding ?? theme.padding,
-            width: width ?? theme.minWidth,
-            height: height ?? theme.maxHeight,
+            width: width ?? (contentWidget == null ? null : theme.minWidth),
+            height: height ?? (contentWidget == null ? null : theme.maxHeight),
             onTap: onTap,
             onLongTap: onLongTap,
             radius:
@@ -163,7 +221,13 @@ class TPopover {
     }
 
     entry = OverlayEntry(
-      builder: (overlayContext) => capturedThemes.wrap(buildOverlayContent()),
+      builder: (overlayContext) => capturedThemes.wrap(
+        _PopoverAnchorLifecycle(
+          anchorContext: context,
+          onAnchorUnmounted: dismiss,
+          child: buildOverlayContent(),
+        ),
+      ),
     );
 
     if (closeOnScroll && scrollPosition != null) {

--- a/tdesign-component/lib/src/components/popover/t_popover_widget.dart
+++ b/tdesign-component/lib/src/components/popover/t_popover_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 import '../../theme/t_colors.dart';
@@ -127,6 +129,9 @@ class TPopoverWidget extends StatefulWidget {
 }
 
 class _TPopoverWidgetState extends State<TPopoverWidget> {
+  TPopoverPlacement _resolvedPlacement = TPopoverPlacement.top;
+  Offset _arrowTranslation = Offset.zero;
+
   TPopoverThemeData get _theme =>
       Theme.of(context).extension<TPopoverThemeData>() ??
       const TPopoverThemeData();
@@ -157,13 +162,6 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
   late Color _color;
 
   late Color _backgroundColor;
-
-  @override
-  void initState() {
-    super.initState();
-    _initTheme();
-    _validateContentSizeContract();
-  }
 
   void _validateContentSizeContract() {
     if (widget.contentWidget == null) {
@@ -196,9 +194,9 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
         style: BorderStyle.solid,
       ),
     );
-    if (widget.placement == TPopoverPlacement.bottom ||
-        widget.placement == TPopoverPlacement.bottomLeft ||
-        widget.placement == TPopoverPlacement.bottomRight) {
+    if (_resolvedPlacement == TPopoverPlacement.bottom ||
+        _resolvedPlacement == TPopoverPlacement.bottomLeft ||
+        _resolvedPlacement == TPopoverPlacement.bottomRight) {
       border = Border(
         top: BorderSide(
           width: _effectiveArrowSize,
@@ -216,9 +214,9 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
           style: BorderStyle.solid,
         ),
       );
-    } else if (widget.placement == TPopoverPlacement.left ||
-        widget.placement == TPopoverPlacement.leftTop ||
-        widget.placement == TPopoverPlacement.leftBottom) {
+    } else if (_resolvedPlacement == TPopoverPlacement.left ||
+        _resolvedPlacement == TPopoverPlacement.leftTop ||
+        _resolvedPlacement == TPopoverPlacement.leftBottom) {
       border = Border(
         top: BorderSide(
           width: _effectiveArrowSize,
@@ -236,9 +234,9 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
           style: BorderStyle.solid,
         ),
       );
-    } else if (widget.placement == TPopoverPlacement.right ||
-        widget.placement == TPopoverPlacement.rightTop ||
-        widget.placement == TPopoverPlacement.rightBottom) {
+    } else if (_resolvedPlacement == TPopoverPlacement.right ||
+        _resolvedPlacement == TPopoverPlacement.rightTop ||
+        _resolvedPlacement == TPopoverPlacement.rightBottom) {
       border = Border(
         top: BorderSide(
           width: _effectiveArrowSize,
@@ -292,6 +290,7 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
         _backgroundColor = widget.context.tTheme.grayColor14;
         break;
     }
+    _backgroundColor = _theme.backgroundColor ?? _backgroundColor;
   }
 
   /// 获取触发元素大小
@@ -328,7 +327,7 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
     var dy = widgetLocalToGlobal?.dy ?? 0;
     var arrowSize = _effectiveShowArrow ? _effectiveArrowSize : 0;
     final popoverHeight = _resolvedPopoverSize().height;
-    switch (widget.placement) {
+    switch (_resolvedPlacement) {
       case TPopoverPlacement.bottomLeft:
       case TPopoverPlacement.bottom:
       case TPopoverPlacement.bottomRight:
@@ -353,7 +352,7 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
     var widgetWidth = widgetBounds?.width ?? 0;
     final popoverWidth = _resolvedPopoverSize().width;
     var dx = widgetLocalToGlobal?.dx ?? 0;
-    switch (widget.placement) {
+    switch (_resolvedPlacement) {
       case TPopoverPlacement.topLeft:
       case TPopoverPlacement.bottomLeft:
         return dx;
@@ -377,7 +376,7 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
   /// todo 通过 CustomPainter 绘制箭头进行优化
   Widget _getArrowWidget() {
     var margin = EdgeInsets.only(top: _effectiveArrowSize);
-    switch (widget.placement) {
+    switch (_resolvedPlacement) {
       case TPopoverPlacement.topLeft:
         margin = EdgeInsets.only(
           top: _effectiveArrowSize,
@@ -438,7 +437,10 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
       default:
         margin = EdgeInsets.only(top: _effectiveArrowSize);
     }
-    return Container(margin: margin, child: _drawArrow());
+    return Transform.translate(
+      offset: _arrowTranslation,
+      child: Container(margin: margin, child: _drawArrow()),
+    );
   }
 
   /// 解析包含 padding 的弹层外框尺寸，供布局和定位共同使用。
@@ -447,17 +449,28 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
       return Size(_effectiveWidth!, _effectiveHeight!);
     }
     final textSize = _getTextSize();
-    return Size(
-      _effectiveWidth ?? textSize.width + _resolvedPadding.horizontal,
-      _effectiveHeight ?? textSize.height + _resolvedPadding.vertical,
-    );
+    final naturalWidth = textSize.width + _resolvedPadding.horizontal;
+    final maxWidth = _effectiveMaxWidth;
+    final resolvedWidth =
+        widget.width ??
+        math.min(maxWidth, math.max(_theme.minWidth ?? 0, naturalWidth));
+    final naturalHeight = textSize.height + _resolvedPadding.vertical;
+    final resolvedHeight =
+        widget.height ??
+        (_theme.maxHeight == null
+            ? naturalHeight
+            : math.min(
+                naturalHeight,
+                math.max(_resolvedPadding.vertical, _theme.maxHeight!),
+              ));
+    return Size(resolvedWidth, resolvedHeight);
   }
 
   /// 获取文本内容大小
   Size _getTextSize() {
     final font = context.tTheme.fontBodyLarge;
     final contentMaxWidth =
-        (_effectiveWidth ?? _effectiveMaxWidth) - _resolvedPadding.horizontal;
+        (widget.width ?? _effectiveMaxWidth) - _resolvedPadding.horizontal;
     var textPainter = TextPainter(
       text: TextSpan(
         text: widget.content,
@@ -511,7 +524,7 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
     var direction = VerticalDirection.down;
 
     /// 设置子Widget垂直排列顺序
-    switch (widget.placement) {
+    switch (_resolvedPlacement) {
       case TPopoverPlacement.bottom:
       case TPopoverPlacement.bottomLeft:
       case TPopoverPlacement.bottomRight:
@@ -533,7 +546,7 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
     }
 
     /// 改变Row和Column交叉轴对齐位置，从而实现箭头位置
-    switch (widget.placement) {
+    switch (_resolvedPlacement) {
       case TPopoverPlacement.topLeft:
       case TPopoverPlacement.bottomLeft:
         axis = CrossAxisAlignment.start;
@@ -555,12 +568,12 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
     }
 
     /// 横向布局
-    if (widget.placement == TPopoverPlacement.right ||
-        widget.placement == TPopoverPlacement.rightTop ||
-        widget.placement == TPopoverPlacement.rightBottom ||
-        widget.placement == TPopoverPlacement.left ||
-        widget.placement == TPopoverPlacement.leftBottom ||
-        widget.placement == TPopoverPlacement.leftTop) {
+    if (_resolvedPlacement == TPopoverPlacement.right ||
+        _resolvedPlacement == TPopoverPlacement.rightTop ||
+        _resolvedPlacement == TPopoverPlacement.rightBottom ||
+        _resolvedPlacement == TPopoverPlacement.left ||
+        _resolvedPlacement == TPopoverPlacement.leftBottom ||
+        _resolvedPlacement == TPopoverPlacement.leftTop) {
       return Row(crossAxisAlignment: axis, children: children);
     }
 
@@ -572,15 +585,225 @@ class _TPopoverWidgetState extends State<TPopoverWidget> {
     );
   }
 
+  TPopoverPlacement _oppositePlacement(TPopoverPlacement placement) {
+    return switch (placement) {
+      TPopoverPlacement.topLeft => TPopoverPlacement.bottomLeft,
+      TPopoverPlacement.top => TPopoverPlacement.bottom,
+      TPopoverPlacement.topRight => TPopoverPlacement.bottomRight,
+      TPopoverPlacement.bottomLeft => TPopoverPlacement.topLeft,
+      TPopoverPlacement.bottom => TPopoverPlacement.top,
+      TPopoverPlacement.bottomRight => TPopoverPlacement.topRight,
+      TPopoverPlacement.leftTop => TPopoverPlacement.rightTop,
+      TPopoverPlacement.left => TPopoverPlacement.right,
+      TPopoverPlacement.leftBottom => TPopoverPlacement.rightBottom,
+      TPopoverPlacement.rightTop => TPopoverPlacement.leftTop,
+      TPopoverPlacement.right => TPopoverPlacement.left,
+      TPopoverPlacement.rightBottom => TPopoverPlacement.leftBottom,
+    };
+  }
+
+  bool _isTopPlacement(TPopoverPlacement placement) =>
+      placement == TPopoverPlacement.topLeft ||
+      placement == TPopoverPlacement.top ||
+      placement == TPopoverPlacement.topRight;
+
+  bool _isBottomPlacement(TPopoverPlacement placement) =>
+      placement == TPopoverPlacement.bottomLeft ||
+      placement == TPopoverPlacement.bottom ||
+      placement == TPopoverPlacement.bottomRight;
+
+  bool _isLeftPlacement(TPopoverPlacement placement) =>
+      placement == TPopoverPlacement.leftTop ||
+      placement == TPopoverPlacement.left ||
+      placement == TPopoverPlacement.leftBottom;
+
+  bool _isRightPlacement(TPopoverPlacement placement) =>
+      placement == TPopoverPlacement.rightTop ||
+      placement == TPopoverPlacement.right ||
+      placement == TPopoverPlacement.rightBottom;
+
+  TPopoverPlacement _resolvePlacement({
+    required TPopoverPlacement requested,
+    required Rect anchorRect,
+    required Rect viewport,
+    required Size totalSize,
+  }) {
+    final requiredVerticalSpace = totalSize.height + _effectiveOffset;
+    final requiredHorizontalSpace = totalSize.width + _effectiveOffset;
+    final hasTopSpace = anchorRect.top - viewport.top >= requiredVerticalSpace;
+    final hasBottomSpace =
+        viewport.bottom - anchorRect.bottom >= requiredVerticalSpace;
+    final hasLeftSpace =
+        anchorRect.left - viewport.left >= requiredHorizontalSpace;
+    final hasRightSpace =
+        viewport.right - anchorRect.right >= requiredHorizontalSpace;
+
+    if (_isTopPlacement(requested) && !hasTopSpace && hasBottomSpace) {
+      return _oppositePlacement(requested);
+    }
+    if (_isBottomPlacement(requested) && !hasBottomSpace && hasTopSpace) {
+      return _oppositePlacement(requested);
+    }
+    if (_isLeftPlacement(requested) && !hasLeftSpace && hasRightSpace) {
+      return _oppositePlacement(requested);
+    }
+    if (_isRightPlacement(requested) && !hasRightSpace && hasLeftSpace) {
+      return _oppositePlacement(requested);
+    }
+    return requested;
+  }
+
+  double _arrowSafeInset(Size popoverSize) {
+    final radius =
+        (_effectiveRadius ??
+                BorderRadius.circular(context.tTheme.radiusDefault))
+            .resolve(Directionality.of(context));
+    final largestRadius = [
+      radius.topLeft.x,
+      radius.topRight.x,
+      radius.bottomLeft.x,
+      radius.bottomRight.x,
+    ].reduce(math.max);
+    final extent =
+        _isLeftPlacement(_resolvedPlacement) ||
+            _isRightPlacement(_resolvedPlacement)
+        ? popoverSize.height
+        : popoverSize.width;
+    return math.min(extent / 2, largestRadius + _effectiveArrowSize);
+  }
+
+  double _baseArrowCenter(Size popoverSize) {
+    final edgeInset = _effectiveArrowSize * 2;
+    return switch (_resolvedPlacement) {
+      TPopoverPlacement.topLeft ||
+      TPopoverPlacement.bottomLeft => edgeInset + 12,
+      TPopoverPlacement.topRight ||
+      TPopoverPlacement.bottomRight => popoverSize.width - edgeInset - 12,
+      TPopoverPlacement.leftTop || TPopoverPlacement.rightTop => edgeInset + 6,
+      TPopoverPlacement.leftBottom ||
+      TPopoverPlacement.rightBottom => popoverSize.height - edgeInset - 6,
+      TPopoverPlacement.top ||
+      TPopoverPlacement.bottom => popoverSize.width / 2,
+      TPopoverPlacement.left ||
+      TPopoverPlacement.right => popoverSize.height / 2,
+    };
+  }
+
+  void _resolveArrowTranslation({
+    required Rect anchorRect,
+    required Size popoverSize,
+    required double left,
+    required double top,
+  }) {
+    if (!_effectiveShowArrow) {
+      _arrowTranslation = Offset.zero;
+      return;
+    }
+    final horizontal =
+        _isLeftPlacement(_resolvedPlacement) ||
+        _isRightPlacement(_resolvedPlacement);
+    final extent = horizontal ? popoverSize.height : popoverSize.width;
+    final desiredCenter = horizontal
+        ? anchorRect.center.dy - top
+        : anchorRect.center.dx - left;
+    final safeInset = _arrowSafeInset(popoverSize);
+    final targetCenter = desiredCenter
+        .clamp(safeInset, math.max(safeInset, extent - safeInset))
+        .toDouble();
+    final translation = targetCenter - _baseArrowCenter(popoverSize);
+    _arrowTranslation = horizontal
+        ? Offset(0, translation)
+        : Offset(translation, 0);
+  }
+
   @override
   Widget build(BuildContext context) {
     _initTheme();
     _validateContentSizeContract();
+    if (widget.context case final Element element when !element.mounted) {
+      return const SizedBox.shrink();
+    }
     var widgetLocalToGlobal = _getWidgetLocalToGlobal(widget.context);
-    var top = _getOffsetTop(widgetLocalToGlobal);
-    var left = _getOffsetLeft(widgetLocalToGlobal);
+
+    final popoverSize = _resolvedPopoverSize();
+    final arrowSize = _effectiveShowArrow ? _effectiveArrowSize : 0;
+    _resolvedPlacement = widget.placement ?? TPopoverPlacement.top;
+    final isHorizontal =
+        _isLeftPlacement(_resolvedPlacement) ||
+        _isRightPlacement(_resolvedPlacement);
+    final totalWidth = popoverSize.width + (isHorizontal ? arrowSize : 0);
+    final totalHeight = popoverSize.height + (isHorizontal ? 0 : arrowSize);
+    final mediaQuery = MediaQuery.of(context);
+    final anchorBounds = _getWidgetBounds(widget.context);
+    final shouldClampToViewport =
+        widgetLocalToGlobal != null &&
+        anchorBounds != null &&
+        anchorBounds.width > 0 &&
+        anchorBounds.height > 0 &&
+        (anchorBounds.width < mediaQuery.size.width ||
+            anchorBounds.height < mediaQuery.size.height);
+    final minLeft = mediaQuery.padding.left;
+    final maxLeft = math.max(
+      minLeft,
+      mediaQuery.size.width - mediaQuery.padding.right - totalWidth,
+    );
+    final minTop = mediaQuery.padding.top;
+    final bottomInset = math.max(
+      mediaQuery.padding.bottom,
+      mediaQuery.viewInsets.bottom,
+    );
+    final viewport = Rect.fromLTRB(
+      minLeft,
+      minTop,
+      mediaQuery.size.width - mediaQuery.padding.right,
+      mediaQuery.size.height - bottomInset,
+    );
+    if (shouldClampToViewport) {
+      final anchorRect = widgetLocalToGlobal & anchorBounds.size;
+      _resolvedPlacement = _resolvePlacement(
+        requested: _resolvedPlacement,
+        anchorRect: anchorRect,
+        viewport: viewport,
+        totalSize: Size(totalWidth, totalHeight),
+      );
+    }
+    final maxTop = math.max(
+      minTop,
+      mediaQuery.size.height - bottomInset - totalHeight,
+    );
+    final rawTop = _getOffsetTop(widgetLocalToGlobal);
+    final rawLeft = _getOffsetLeft(widgetLocalToGlobal);
+    final top = !shouldClampToViewport
+        ? rawTop
+        : rawTop.clamp(minTop, maxTop).toDouble();
+    final left = !shouldClampToViewport
+        ? rawLeft
+        : rawLeft.clamp(minLeft, maxLeft).toDouble();
+    if (shouldClampToViewport) {
+      _resolveArrowTranslation(
+        anchorRect: widgetLocalToGlobal & anchorBounds.size,
+        popoverSize: popoverSize,
+        left: left,
+        top: top,
+      );
+    } else {
+      _arrowTranslation = Offset.zero;
+    }
+    var popover = _getChild();
+    if (widget.onTap != null || widget.onLongTap != null) {
+      popover = GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: widget.onTap == null
+            ? null
+            : () => widget.onTap!.call(widget.content),
+        onLongPress: widget.onLongTap == null
+            ? null
+            : () => widget.onLongTap!.call(widget.content),
+        child: popover,
+      );
+    }
     return Stack(
-      children: [Positioned(top: top, left: left, child: _getChild())],
+      children: [Positioned(top: top, left: left, child: popover)],
     );
   }
 }

--- a/tdesign-component/test/components/popover/t_popover_test.dart
+++ b/tdesign-component/test/components/popover/t_popover_test.dart
@@ -114,6 +114,39 @@ void main() {
       expect(decoration.color, token.grayColor14);
     });
 
+    testWidgets('主题 backgroundColor 覆盖语义色的背景 token', (tester) async {
+      await tester.pumpWidget(
+        wrapWithTheme(
+          Builder(
+            builder: (context) {
+              return Center(
+                child: TPopoverWidget(
+                  context: context,
+                  content: '自定义背景',
+                  colorScheme: TPopoverColorScheme.info,
+                ),
+              );
+            },
+          ),
+          popoverTheme: const TPopoverThemeData(backgroundColor: Colors.black),
+        ),
+      );
+      await tester.pump();
+
+      final container = tester.widget<Container>(
+        find
+            .descendant(
+              of: find.byType(TPopoverWidget),
+              matching: find.byWidgetPredicate(
+                (widget) =>
+                    widget is Container && widget.decoration is BoxDecoration,
+              ),
+            )
+            .first,
+      );
+      expect((container.decoration! as BoxDecoration).color, Colors.black);
+    });
+
     testWidgets('长文本默认限制在测量宽度内并允许换行', (tester) async {
       const longContent = '这是一段非常非常非常非常非常非常非常长的气泡内容，用于验证默认宽度不会横向无限延伸';
       await tester.pumpWidget(
@@ -433,6 +466,33 @@ void main() {
       expect(tester.getSize(containerFinder).width, lessThanOrEqualTo(180));
     });
 
+    testWidgets('theme maxHeight 是文本气泡的最大高度而非固定高度', (tester) async {
+      await tester.pumpWidget(
+        wrapWithTheme(
+          Builder(
+            builder: (context) {
+              return Center(
+                child: TPopoverWidget(context: context, content: '短文本'),
+              );
+            },
+          ),
+          popoverTheme: const TPopoverThemeData(maxHeight: 200),
+        ),
+      );
+      await tester.pump();
+
+      final containerFinder = find
+          .descendant(
+            of: find.byType(TPopoverWidget),
+            matching: find.byWidgetPredicate(
+              (widget) =>
+                  widget is Container && widget.decoration is BoxDecoration,
+            ),
+          )
+          .first;
+      expect(tester.getSize(containerFinder).height, lessThan(200));
+    });
+
     testWidgets('自定义 radius 圆角', (tester) async {
       await tester.pumpWidget(
         wrapWithTheme(
@@ -618,7 +678,6 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('可关闭'), findsOneWidget);
-
       // 点击外部关闭
       await tester.tapAt(const Offset(10, 10));
       await tester.pumpAndSettle();
@@ -734,6 +793,247 @@ void main() {
 
       await tester.tapAt(const Offset(10, 10));
       await tester.pump();
+      expect(completed, isTrue);
+    });
+
+    testWidgets('Popover 点击和长按回调会传递 content', (tester) async {
+      late BuildContext ctx;
+      String? tapped;
+      String? longPressed;
+      await tester.pumpWidget(
+        wrapWithTheme(
+          Builder(
+            builder: (context) {
+              ctx = context;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      unawaited(
+        TPopover.showPopover(
+          context: ctx,
+          content: '回调内容',
+          placement: TPopoverPlacement.bottom,
+          onTap: (content) => tapped = content,
+          onLongTap: (content) => longPressed = content,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('回调内容'));
+      expect(tapped, '回调内容');
+      await tester.longPress(find.text('回调内容'));
+      expect(longPressed, '回调内容');
+    });
+
+    testWidgets('右下角锚点的 Popover 保持在安全区内', (tester) async {
+      late BuildContext anchorContext;
+      await tester.pumpWidget(
+        wrapWithTheme(
+          Align(
+            alignment: Alignment.bottomRight,
+            child: Builder(
+              builder: (context) {
+                anchorContext = context;
+                return const SizedBox(width: 40, height: 40);
+              },
+            ),
+          ),
+        ),
+      );
+
+      unawaited(
+        TPopover.showPopover(
+          context: anchorContext,
+          content: '右下角的较长气泡内容',
+          placement: TPopoverPlacement.bottomRight,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final textRect = tester.getRect(find.text('右下角的较长气泡内容'));
+      final viewSize = tester.view.physicalSize / tester.view.devicePixelRatio;
+      expect(textRect.left, greaterThanOrEqualTo(0));
+      expect(textRect.top, greaterThanOrEqualTo(0));
+      expect(textRect.right, lessThanOrEqualTo(viewSize.width));
+      expect(textRect.bottom, lessThanOrEqualTo(viewSize.height));
+    });
+
+    testWidgets('top 上方空间不足时翻转到 bottom', (tester) async {
+      late BuildContext anchorContext;
+      const anchorKey = Key('top-flip-anchor');
+      await tester.pumpWidget(
+        wrapWithTheme(
+          Align(
+            alignment: Alignment.topCenter,
+            child: Builder(
+              builder: (context) {
+                anchorContext = context;
+                return const SizedBox(key: anchorKey, width: 40, height: 40);
+              },
+            ),
+          ),
+        ),
+      );
+
+      unawaited(
+        TPopover.showPopover(
+          context: anchorContext,
+          content: '自动翻转到底部',
+          placement: TPopoverPlacement.top,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final anchorRect = tester.getRect(find.byKey(anchorKey));
+      final popoverRect = tester.getRect(find.text('自动翻转到底部'));
+      expect(popoverRect.top, greaterThanOrEqualTo(anchorRect.bottom));
+      final border =
+          tester.widget<Container>(arrowContainerFinder()).decoration
+              as BoxDecoration;
+      expect((border.border! as Border).top.color, isNot(Colors.transparent));
+    });
+
+    testWidgets('left 左侧空间不足时翻转到 right', (tester) async {
+      late BuildContext anchorContext;
+      const anchorKey = Key('left-flip-anchor');
+      await tester.pumpWidget(
+        wrapWithTheme(
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Builder(
+              builder: (context) {
+                anchorContext = context;
+                return const SizedBox(key: anchorKey, width: 40, height: 40);
+              },
+            ),
+          ),
+        ),
+      );
+
+      unawaited(
+        TPopover.showPopover(
+          context: anchorContext,
+          content: '自动翻转到右侧',
+          placement: TPopoverPlacement.left,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final anchorRect = tester.getRect(find.byKey(anchorKey));
+      final popoverRect = tester.getRect(find.text('自动翻转到右侧'));
+      expect(popoverRect.left, greaterThanOrEqualTo(anchorRect.right));
+      final border =
+          tester.widget<Container>(arrowContainerFinder()).decoration
+              as BoxDecoration;
+      expect((border.border! as Border).left.color, isNot(Colors.transparent));
+    });
+
+    testWidgets('两侧空间都不足时 clamp 并补偿箭头位置', (tester) async {
+      tester.view.physicalSize = const Size(240, 180);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      late BuildContext anchorContext;
+      await tester.pumpWidget(
+        wrapWithTheme(
+          Align(
+            alignment: Alignment.centerRight,
+            child: Builder(
+              builder: (context) {
+                anchorContext = context;
+                return const SizedBox(width: 40, height: 40);
+              },
+            ),
+          ),
+        ),
+      );
+
+      unawaited(
+        TPopover.showPopover(
+          context: anchorContext,
+          contentWidget: const ColoredBox(
+            key: Key('clamped-popover-content'),
+            color: Colors.red,
+          ),
+          width: 180,
+          height: 150,
+          placement: TPopoverPlacement.top,
+          radius: BorderRadius.circular(20),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final contentRect = tester.getRect(
+        find.byKey(const Key('clamped-popover-content')),
+      );
+      expect(contentRect.left, greaterThanOrEqualTo(0));
+      expect(contentRect.top, greaterThanOrEqualTo(0));
+      expect(contentRect.right, lessThanOrEqualTo(240));
+      expect(contentRect.bottom, lessThanOrEqualTo(180));
+      final arrowTransform = tester.widget<Transform>(
+        find
+            .ancestor(
+              of: arrowContainerFinder(),
+              matching: find.byType(Transform),
+            )
+            .first,
+      );
+      final arrowTranslation = arrowTransform.transform.getTranslation().x;
+      final resolvedArrowCenter = 90 + arrowTranslation;
+      expect(arrowTranslation, greaterThan(0));
+      expect(resolvedArrowCenter, greaterThanOrEqualTo(28));
+      expect(resolvedArrowCenter, lessThanOrEqualTo(152));
+    });
+
+    testWidgets('锚点销毁后清理 Overlay 并完成 showPopover Future', (tester) async {
+      late BuildContext anchorContext;
+      late StateSetter setHostState;
+      var showAnchor = true;
+      var completed = false;
+      await tester.pumpWidget(
+        wrapWithTheme(
+          StatefulBuilder(
+            builder: (context, setState) {
+              setHostState = setState;
+              return Stack(
+                children: [
+                  if (showAnchor)
+                    Align(
+                      alignment: Alignment.center,
+                      child: Builder(
+                        builder: (context) {
+                          anchorContext = context;
+                          return const SizedBox(width: 40, height: 40);
+                        },
+                      ),
+                    ),
+                ],
+              );
+            },
+          ),
+        ),
+      );
+
+      unawaited(
+        TPopover.showPopover(
+          context: anchorContext,
+          content: '随锚点关闭',
+          placement: TPopoverPlacement.bottom,
+        ).then((_) => completed = true),
+      );
+      await tester.pump();
+      expect(find.text('随锚点关闭'), findsOneWidget);
+      expect(completed, isFalse);
+
+      setHostState(() => showAnchor = false);
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('随锚点关闭'), findsNothing);
+      expect(find.byKey(const Key('t-popover-outside-dismiss')), findsNothing);
       expect(completed, isTrue);
     });
   });


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？
> 勾选规则:
> 1.只要有新增参数，就勾选”新特性提交“
> 2.只修改内部bug，未新增参数，才勾选”日常 bug 修复“
> 3.其他选项视具体改动判断

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无关联 Issue，本 PR 来源于 Popover 发板前组件审查。

### 💡 需求背景和解决方案

Popover 发板前审查发现以下运行时契约缺口：公开的点击/长按回调未生效，主题背景色和尺寸约束未完整消费，边缘或键盘场景可能越出可用视口，锚点销毁后 OverlayEntry、监听器和 `showPopover` Future 未主动清理。

本 PR：

- 落实点击/长按回调、主题背景色以及自然尺寸上下限。
- 根据安全区和键盘 `viewInsets` 计算可用视口；请求方向空间不足时同轴翻转，两侧都不足时再 clamp。
- clamp 后补偿箭头位置，并限制在圆角安全区域内，使箭头继续指向锚点。
- 锚点销毁后复用幂等 dismiss 路径，清理 OverlayEntry、滚动监听和未完成 Future。
- 增加事件、自定义内容、主题尺寸、四角边界、键盘和生命周期 Demo，并同步生成代码片段。

未新增、删除或修改公共 API 签名。完整行为契约和验收记录见 [Popover Contract Hardening Spec](https://github.com/Tencent/tdesign-flutter/tree/rss1102/fix-popover-contracts/specs/003-popover-contract-hardening)。

交互变化可在 Example 的 Popover 页面“交互与边界”模块中直接验证；Preview 构建完成后可通过 PR Preview 复验。

验证结果：

- 68 项 Popover、Golden 和关联 Popup/主题测试通过。
- 4 项 Popover Example Widget 测试通过。
- 组件与 Example 定向 `flutter analyze` 通过。
- Example Web 构建通过。
- 示例代码生成 `--check`、56 条组件文档契约和 `git diff --check` 通过。

### 📝 更新日志

- fix(TPopover): 修复交互、主题、尺寸、边界定位及锚点销毁后的浮层清理问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 标题遵循 Conventional Commits 格式：`type(scope): 修改描述`；`scope` 可填写组件、文档或 CI 模块（示例：`fix(TBottomTabBar): 修复 iconText 模式底部溢出`、`docs(contributing): 更新 PR 提交流程`）
- [ ] ”相关issue“处带上修复的issue链接（本 PR 无关联 Issue）
- [x] 已添加对应的 Spec 链接，或已由 Review 确认本次改动无需 Spec
- [x] 相关文档已补充或无须补充
