### PR TITLE
fix(example): follow Flutter SDK intl version

### DIFF
--- a/tdesign-component/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/tdesign-component/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/tdesign-component/example/android/settings.gradle
+++ b/tdesign-component/example/android/settings.gradle
@@ -20,8 +20,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0" // 声明式加载插件
-    id "com.android.application" version "8.9.1" apply false // 根据实际 AGP 版本调整
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false // Kotlin 版本需兼容 AGP
+    id "com.android.application" version "8.11.1" apply false // 根据实际 AGP 版本调整
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false // Kotlin 版本需兼容 AGP
 }
 
 include ":app"

--- a/tdesign-component/example/pubspec.yaml
+++ b/tdesign-component/example/pubspec.yaml
@@ -30,6 +30,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   web: 1.1.1
 
   #轮播图组件
@@ -55,8 +57,6 @@ dependencies:
 
 dev_dependencies:
   flutter_test:
-    sdk: flutter
-  flutter_localizations:
     sdk: flutter
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/tdesign-component/example/pubspec.yaml
+++ b/tdesign-component/example/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   web: 1.1.1
 
   #轮播图组件
-  intl: 0.20.2
+  intl: any
   
   # 农历支持
   lunar: ^1.7.8


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？
> 勾选规则:
> 1.只要有新增参数，就勾选”新特性提交“
> 2.只修改内部bug，未新增参数，才勾选”日常 bug 修复“
> 3.其他选项视具体改动判断

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无关联 Issue。

### 💡 需求背景和解决方案

示例工程将 `intl` 固定为 `0.20.2`。Flutter 3.47.0 的 `flutter_localizations` 要求 `intl ^0.20.3`，导致 latest CI 在 `flutter pub get` 阶段依赖解析失败。

将示例工程的直接依赖调整为 `intl: any`，让 Pub 使用 Flutter SDK 通过 `flutter_localizations` 提供的版本约束：

- Flutter 3.32.0 解析为 `intl 0.20.2`；
- Flutter 3.47.0 解析为 `intl 0.20.3`。

该修改不改变组件公共 API 或默认行为，不属于 breaking change，无需 Spec。

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 标题遵循 Conventional Commits 格式：`type(scope): 修改描述`；`scope` 可填写组件、文档或 CI 模块（示例：`fix(TBottomTabBar): 修复 iconText 模式底部溢出`、`docs(contributing): 更新 PR 提交流程`）
- [x] ”相关issue“处带上修复的issue链接，或已说明无关联 Issue
- [x] 已添加对应的 Spec 链接，或已由 Review 确认本次改动无需 Spec
- [x] 相关文档已补充或无须补充

### ✅ 验证

- Flutter 3.32.0：`flutter pub get` 通过，解析 `intl 0.20.2`
- Flutter 3.47.0（当前 stable/latest）：`flutter pub get` 通过，解析 `intl 0.20.3`
- `git diff --check` 通过
