### PR TITLE
fix(checkbox): 修复样式尺寸未跟随主题 token

### DIFF
--- a/specs/016-checkbox-theme-token-sizes/acceptance.md
+++ b/specs/016-checkbox-theme-token-sizes/acceptance.md
@@ -1,0 +1,23 @@
+# 验收记录
+
+## 验证环境
+
+- 分支：`rss1102/refactor/checkbox-theme-tokens`
+- 基线：`origin/develop@fab17971`
+- Flutter：3.32.0 / Dart 3.8.0；3.47.0
+
+## 自动化验证
+
+| 命令 | 结果 | 备注 |
+| --- | --- | --- |
+| Flutter 3.32.0 Checkbox tests | 通过 | Checkbox/Group/SelectionCard 共 42 tests |
+| Flutter 3.47.0 Checkbox tests | 通过 | Checkbox/Group/SelectionCard 共 42 tests |
+| Flutter 3.32.0 analyze | 通过 | 0 issues，`--fatal-infos` |
+| Flutter 3.47.0 analyze | 通过 | 0 issues，`--fatal-infos` |
+| Flutter 3.32.0 Linux Checkbox Golden | 通过 | Demo structure、light/dark，共 3 tests；无更新模式 |
+| Flutter 3.32.0 coverage | 通过 | 改动生产文件 249/261，95.40% |
+
+## 结论
+
+- 默认 token 下 Golden 无差异，不改变 Checkbox 公开 API、默认视觉或交互行为。
+- 自定义 spacer/font token 已覆盖块高、指示器、卡片高度、边框、角标尺寸和角标圆角路径。

--- a/specs/016-checkbox-theme-token-sizes/plan.md
+++ b/specs/016-checkbox-theme-token-sizes/plan.md
@@ -1,0 +1,29 @@
+# 实施方案
+
+## 技术方案
+
+使用现有 TDesign spacer、字体和行高 token 组合现有默认尺寸：48、64 直接读取对应 spacer；56 由 48 + 8 组合；20、28 由 16/24 + 4 组合。卡片高度由标题/副标题行高、4dp 文案间距及上下 16dp 内边距计算。卡片边框宽度和角标圆角由 `spacer4` 派生；角标使用 24dp 与 24 + 4dp token，内部图标和偏移使用相对于角标尺寸的几何比例。
+
+## 影响范围
+
+| 范围 | 文件或模块 | 影响 |
+| --- | --- | --- |
+| 组件 | `t_check_box.dart` | 块高、指示器和卡片高度改为 token 计算 |
+| 共享布局 | `t_selection_card.dart` | 卡片组高度和角标尺寸改为 token 计算 |
+| 测试 | Checkbox component tests | 覆盖默认值与自定义 token 路径 |
+
+## API 变化
+
+无公开 API 变化。
+
+## 风险与取舍
+
+- 默认 token 下计算结果必须与既有直接数值完全一致，避免 Golden 变化。
+- 自定义 spacer/font token 后 Checkbox 尺寸会随主题变化，这是修复目的；既有未自定义主题的用户无感。
+- 路径曲线、画笔比例等纯几何常量保留在绘制实现中。
+
+## 验证策略
+
+- Widget 测试验证默认尺寸及自定义 token 后的实际布局尺寸。
+- Flutter 3.32.0 与 latest 运行 Checkbox/Group 测试和严格 analyze。
+- Flutter 3.32.0 Linux 运行 Checkbox light/dark Golden，不更新基线时应直接通过。

--- a/specs/016-checkbox-theme-token-sizes/spec.md
+++ b/specs/016-checkbox-theme-token-sizes/spec.md
@@ -1,0 +1,49 @@
+# Checkbox 样式尺寸 token 化
+
+## 背景
+
+`TCheckbox` 与其共享卡片布局仍直接使用 20 / 24 / 28、48 / 56 / 64、56 / 82 等样式尺寸。默认主题下视觉正确，但这些值不会随 TDesign 间距、字体和行高 token 调整，与仓库“样式属性定义在主题中”的约定不一致。
+
+## 目标
+
+- Checkbox 三档块高与指示器尺寸由 TDesign token 计算。
+- Checkbox 单项及卡片组高度由字体、行高和间距 token 计算。
+- 共享选择卡片的边框、角标尺寸与角标圆角由 TDesign token 计算。
+- 默认主题下保持现有视觉尺寸和行为不变。
+
+## 非目标
+
+- 不新增或修改 Checkbox 公开构造参数。
+- 不改变选中、半选、禁用、回调、分割线或布局语义。
+- 不把绘制比例、路径控制点等纯几何关系伪装为样式 token。
+- 不调整 Radio 的公开 API 或默认行为。
+
+## 范围
+
+### 涉及
+
+- `TCheckbox` 内部尺寸解析。
+- `TSelectionCard` 与 `TSelectionCardGroupLayout` 的内部尺寸解析。
+- Checkbox 与共享卡片组件测试。
+
+### 不涉及
+
+- Checkbox Demo 结构、文案和交互。
+- 新增 ThemeExtension 字段。
+- 其他组件的样式重构。
+
+## 行为契约
+
+- 默认主题下 small / medium / large 带文案 Checkbox 高度仍为 48 / 56 / 64dp，指示器仍为 20 / 24 / 28dp。
+- 默认主题下无副标题 / 有副标题的选择卡片高度仍为 56 / 82dp。
+- 默认主题下选择卡片边框仍为 1.5dp、角标圆角仍为 4dp；纵向 / 横向角标仍分别为 28 / 24dp，勾选图标仍为角标的一半。
+- 覆盖相关 TDesign spacer、字体或行高 token 后，上述尺寸随 token 重新计算。
+- 绘制器中的无量纲比例和路径控制点不属于可配置样式尺寸，不纳入 token 化范围。
+
+## 验收标准
+
+- [ ] 默认主题下 Checkbox 与卡片尺寸无视觉变化。
+- [ ] 自定义 token 能改变 Checkbox 块高、指示器、卡片高度、边框与角标尺寸。
+- [ ] Checkbox 受控交互、禁用、半选和 Group 行为测试保持通过。
+- [ ] Flutter 3.32.0 与 latest 的相关功能测试及 analyze 零告警。
+- [ ] Flutter 3.32.0 Linux 的 Checkbox light/dark Golden 无差异通过。

--- a/specs/016-checkbox-theme-token-sizes/tasks.md
+++ b/specs/016-checkbox-theme-token-sizes/tasks.md
@@ -1,0 +1,8 @@
+# 任务拆分
+
+- [x] 冻结最新 develop 基线并审计直接样式数值。
+- [x] 将 TCheckbox 尺寸改为 TDesign token 计算。
+- [x] 将共享选择卡片高度、边框与角标尺寸改为 TDesign token 计算。
+- [x] 补充默认值与自定义 token 测试。
+- [x] 完成 Flutter 3.32.0、latest 与 Linux Golden 验证。
+- [x] 完成提交前范围与生成产物核验。

--- a/tdesign-component/lib/src/components/checkbox/t_check_box.dart
+++ b/tdesign-component/lib/src/components/checkbox/t_check_box.dart
@@ -123,7 +123,7 @@ class TCheckbox extends StatelessWidget {
     final hasContent = content != null;
 
     final constraints = hasContent
-        ? BoxConstraints(minHeight: _contentMinHeight)
+        ? BoxConstraints(minHeight: _contentMinHeight(context))
         : _resolveTapTargetConstraints(context);
 
     final tileContent = LayoutBuilder(
@@ -181,7 +181,7 @@ class TCheckbox extends StatelessWidget {
             backgroundColor:
                 theme?.backgroundColor ?? context.tTheme.bgColorContainer,
             borderRadius: context.tTheme.radiusDefault,
-            minHeight: subTitle?.isNotEmpty == true ? 82 : 56,
+            minHeight: _cardMinHeight(context),
             child: tileContent,
           )
         : tileContent;
@@ -214,17 +214,30 @@ class TCheckbox extends StatelessWidget {
     );
   }
 
-  double get _contentMinHeight => switch (size) {
-    TCheckboxSize.small => 48.0,
-    TCheckboxSize.medium => 56.0,
-    TCheckboxSize.large => 64.0,
+  double _contentMinHeight(BuildContext context) => switch (size) {
+    TCheckboxSize.small => context.tTheme.spacer48,
+    TCheckboxSize.medium => context.tTheme.spacer48 + context.tTheme.spacer8,
+    TCheckboxSize.large => context.tTheme.spacer64,
   };
 
-  double get _indicatorSize => switch (size) {
-    TCheckboxSize.small => 20.0,
-    TCheckboxSize.medium => 24.0,
-    TCheckboxSize.large => 28.0,
+  double _indicatorSize(BuildContext context) => switch (size) {
+    TCheckboxSize.small => context.tTheme.spacer16 + context.tTheme.spacer4,
+    TCheckboxSize.medium => context.tTheme.spacer24,
+    TCheckboxSize.large => context.tTheme.spacer24 + context.tTheme.spacer4,
   };
+
+  double _cardMinHeight(BuildContext context) {
+    final titleHeight = _textLineHeight(_resolveTitleStyle(context));
+    final contentHeight = subTitle?.isNotEmpty == true
+        ? titleHeight +
+              context.tTheme.spacer4 +
+              _textLineHeight(_resolveSubTitleStyle(context))
+        : titleHeight;
+    return contentHeight + context.tTheme.spacer16 * 2;
+  }
+
+  double _textLineHeight(TextStyle style) =>
+      style.fontSize! * (style.height ?? 1);
 
   BoxConstraints _resolveTapTargetConstraints(BuildContext context) {
     final materialTheme = CheckboxTheme.of(context);
@@ -237,13 +250,14 @@ class TCheckbox extends StatelessWidget {
         materialTheme.materialTapTargetSize ??
         appTheme.tExplicitMaterialTapTargetSize ??
         MaterialTapTargetSize.padded;
+    final indicatorSize = _indicatorSize(context);
     final baseSize = tapTargetSize == MaterialTapTargetSize.padded
         ? kMinInteractiveDimension
-        : _indicatorSize;
+        : indicatorSize;
     final adjustment = visualDensity.baseSizeAdjustment;
     return BoxConstraints(
-      minWidth: math.max(_indicatorSize, baseSize + adjustment.dx),
-      minHeight: math.max(_indicatorSize, baseSize + adjustment.dy),
+      minWidth: math.max(indicatorSize, baseSize + adjustment.dx),
+      minHeight: math.max(indicatorSize, baseSize + adjustment.dy),
     );
   }
 
@@ -288,32 +302,44 @@ class TCheckbox extends StatelessWidget {
         : (materialTheme.side?.color ??
               colorScheme?.outline ??
               context.tTheme.componentBorderColor);
+    final indicatorSize = _indicatorSize(context);
     return SizedBox(
-      width: _indicatorSize,
-      height: _indicatorSize,
+      width: indicatorSize,
+      height: indicatorSize,
       child: icon == null
           ? null
-          : Icon(icon, size: _indicatorSize, color: color),
+          : Icon(icon, size: indicatorSize, color: color),
     );
+  }
+
+  TextStyle _resolveTitleStyle(BuildContext context) {
+    final materialTextTheme = Theme.of(context).tExplicitTextTheme;
+    final materialFallback = Theme.of(context).textTheme.bodyLarge;
+    final titleFont = context.tTheme.fontBodyLarge;
+    return TextStyle(
+      fontSize: titleFont?.size ?? materialFallback?.fontSize,
+      height: titleFont?.height ?? materialFallback?.height,
+      fontWeight: titleFont?.fontWeight ?? materialFallback?.fontWeight,
+    ).merge(materialTextTheme?.bodyLarge ?? materialTextTheme?.bodyMedium);
+  }
+
+  TextStyle _resolveSubTitleStyle(BuildContext context) {
+    final materialTextTheme = Theme.of(context).tExplicitTextTheme;
+    final materialFallback = Theme.of(context).textTheme.bodyMedium;
+    final subtitleFont = context.tTheme.fontBodyMedium;
+    return TextStyle(
+      fontSize: subtitleFont?.size ?? materialFallback?.fontSize,
+      height: subtitleFont?.height ?? materialFallback?.height,
+      fontWeight: subtitleFont?.fontWeight ?? materialFallback?.fontWeight,
+    ).merge(materialTextTheme?.bodyMedium ?? materialTextTheme?.bodySmall);
   }
 
   Widget? _buildContent(BuildContext context, TCheckboxThemeData? theme) {
     if (title == null && subTitle == null) {
       return null;
     }
-    final materialTextTheme = Theme.of(context).tExplicitTextTheme;
-    final titleFont = context.tTheme.fontBodyLarge;
-    final titleStyle = TextStyle(
-      fontSize: titleFont?.size ?? 16,
-      height: titleFont?.height,
-      fontWeight: titleFont?.fontWeight ?? FontWeight.w400,
-    ).merge(materialTextTheme?.bodyLarge ?? materialTextTheme?.bodyMedium);
-    final subtitleFont = context.tTheme.fontBodyMedium;
-    final subTitleStyle = TextStyle(
-      fontSize: subtitleFont?.size ?? 14,
-      height: subtitleFont?.height,
-      fontWeight: subtitleFont?.fontWeight ?? FontWeight.w400,
-    ).merge(materialTextTheme?.bodyMedium ?? materialTextTheme?.bodySmall);
+    final titleStyle = _resolveTitleStyle(context);
+    final subTitleStyle = _resolveSubTitleStyle(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,

--- a/tdesign-component/lib/src/components/checkbox/t_selection_card.dart
+++ b/tdesign-component/lib/src/components/checkbox/t_selection_card.dart
@@ -1,9 +1,43 @@
 import 'package:flutter/material.dart';
 import 'package:tdesign_flutter_icons/tdesign_flutter_icons.dart' show TIcons;
 
+import '../../theme/basic.dart';
 import '../../theme/t_colors.dart';
+import '../../theme/t_fonts.dart';
 import '../../theme/t_spacers.dart';
 import '../../theme/t_theme.dart';
+
+double _fontLineHeight(
+  Font? font,
+  TextStyle? explicitStyle,
+  TextStyle? materialFallback,
+) {
+  final style = TextStyle(
+    fontSize: font?.size ?? materialFallback?.fontSize,
+    height: font?.height ?? materialFallback?.height,
+  ).merge(explicitStyle);
+  return style.fontSize! * (style.height ?? 1);
+}
+
+double _selectionCardHeight(BuildContext context, bool hasSubtitle) {
+  final materialTheme = Theme.of(context);
+  final explicitTextTheme = materialTheme.tExplicitTextTheme;
+  final titleHeight = _fontLineHeight(
+    context.tTheme.fontBodyLarge,
+    explicitTextTheme?.bodyLarge ?? explicitTextTheme?.bodyMedium,
+    materialTheme.textTheme.bodyLarge,
+  );
+  final contentHeight = hasSubtitle
+      ? titleHeight +
+            context.tTheme.spacer4 +
+            _fontLineHeight(
+              context.tTheme.fontBodyMedium,
+              explicitTextTheme?.bodyMedium ?? explicitTextTheme?.bodySmall,
+              materialTheme.textTheme.bodyMedium,
+            )
+      : titleHeight;
+  return contentHeight + context.tTheme.spacer16 * 2;
+}
 
 /// 复选框或单选框使用的卡片式选择容器。
 class TSelectionCard extends StatelessWidget {
@@ -32,13 +66,15 @@ class TSelectionCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final stateColor = disabled ? disabledColor : selectedColor;
     final markStyle = _SelectionCardMarkStyle.maybeOf(context);
+    final defaultMarkSize = context.tTheme.spacer24 + context.tTheme.spacer4;
+    final markSize = markStyle?.size ?? defaultMarkSize;
     return Container(
       constraints: BoxConstraints(minHeight: minHeight),
       clipBehavior: Clip.hardEdge,
       decoration: BoxDecoration(
         color: backgroundColor,
         border: Border.all(
-          width: 1.5,
+          width: context.tTheme.spacer4 * 3 / 8,
           color: selected ? stateColor : Colors.transparent,
         ),
         borderRadius: BorderRadius.circular(borderRadius),
@@ -52,9 +88,11 @@ class TSelectionCard extends StatelessWidget {
               left: 0,
               child: _SelectionCardMark(
                 color: stateColor,
-                size: markStyle?.size ?? 28,
-                iconSize: markStyle?.iconSize ?? 14,
-                iconOffset: markStyle?.iconOffset ?? const Offset(2, 3),
+                size: markSize,
+                iconSize: markStyle?.iconSize ?? markSize / 2,
+                iconOffset:
+                    markStyle?.iconOffset ??
+                    Offset(markSize / 14, markSize * 3 / 28),
               ),
             ),
         ],
@@ -90,7 +128,7 @@ class TSelectionCardGroupLayout extends StatelessWidget {
           children: [
             for (var index = 0; index < children.length; index++) ...[
               SizedBox(
-                height: itemHasSubtitles[index] ? 82 : 56,
+                height: _selectionCardHeight(context, itemHasSubtitles[index]),
                 child: children[index],
               ),
               if (index < children.length - 1)
@@ -111,9 +149,11 @@ class TSelectionCardGroupLayout extends StatelessWidget {
         final itemWidth = availableWidth == null
             ? null
             : (availableWidth - spacing * (columns - 1)) / columns;
-        final itemHeight = itemHasSubtitles.any((hasSubtitle) => hasSubtitle)
-            ? 82.0
-            : 56.0;
+        final itemHeight = _selectionCardHeight(
+          context,
+          itemHasSubtitles.any((hasSubtitle) => hasSubtitle),
+        );
+        final markSize = context.tTheme.spacer24;
         return Padding(
           padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
           child: Wrap(
@@ -125,9 +165,9 @@ class TSelectionCardGroupLayout extends StatelessWidget {
                   width: itemWidth,
                   height: itemHeight,
                   child: _SelectionCardMarkStyle(
-                    size: 24,
-                    iconSize: 12,
-                    iconOffset: const Offset(1.5, 1.5),
+                    size: markSize,
+                    iconSize: markSize / 2,
+                    iconOffset: Offset(markSize / 16, markSize / 16),
                     child: child,
                   ),
                 ),
@@ -162,7 +202,10 @@ class _SelectionCardMark extends StatelessWidget {
         children: [
           CustomPaint(
             size: Size.square(size),
-            painter: _SelectionCardMarkPainter(color),
+            painter: _SelectionCardMarkPainter(
+              color,
+              cornerRadius: context.tTheme.spacer4,
+            ),
           ),
           Positioned(
             top: iconOffset.dy,
@@ -205,9 +248,10 @@ class _SelectionCardMarkStyle extends InheritedWidget {
 }
 
 class _SelectionCardMarkPainter extends CustomPainter {
-  const _SelectionCardMarkPainter(this.color);
+  const _SelectionCardMarkPainter(this.color, {required this.cornerRadius});
 
   final Color color;
+  final double cornerRadius;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -216,8 +260,8 @@ class _SelectionCardMarkPainter extends CustomPainter {
       ..color = color
       ..style = PaintingStyle.fill;
     final path = Path()
-      ..moveTo(0, 4)
-      ..quadraticBezierTo(0, 0, 4, 0)
+      ..moveTo(0, cornerRadius)
+      ..quadraticBezierTo(0, 0, cornerRadius, 0)
       ..lineTo(size.width, 0)
       ..lineTo(0, size.height)
       ..close();
@@ -226,6 +270,7 @@ class _SelectionCardMarkPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant _SelectionCardMarkPainter oldDelegate) {
-    return color != oldDelegate.color;
+    return color != oldDelegate.color ||
+        cornerRadius != oldDelegate.cornerRadius;
   }
 }

--- a/tdesign-component/test/components/checkbox/t_check_box_group_test.dart
+++ b/tdesign-component/test/components/checkbox/t_check_box_group_test.dart
@@ -4,9 +4,9 @@ import 'package:tdesign_flutter/src/components/checkbox/t_selection_card.dart';
 import 'package:tdesign_flutter/tdesign_flutter.dart';
 
 void main() {
-  Widget wrap(Widget child) {
+  Widget wrap(Widget child, {TThemeData? token}) {
     return MaterialApp(
-      theme: TThemeBuilder.light(TThemeData.defaultData()),
+      theme: TThemeBuilder.light(token ?? TThemeData.defaultData()),
       home: Scaffold(body: child),
     );
   }
@@ -368,6 +368,104 @@ void main() {
         find.byWidgetPredicate(
           (widget) =>
               widget is CustomPaint && widget.size == const Size.square(24),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('卡片高度与角标尺寸读取 TDesign token', (tester) async {
+      final token = TThemeData.defaultData().copyWithTThemeData(
+        'selection-card-token-test',
+        fontMap: {
+          'fontBodyLarge': Font(size: 17, lineHeight: 26),
+          'fontBodyMedium': Font(size: 15, lineHeight: 23),
+        },
+        marginMap: const {'spacer4': 5, 'spacer16': 18, 'spacer24': 27},
+      );
+      Widget selectedCard() => const TSelectionCard(
+        selected: true,
+        disabled: false,
+        selectedColor: Colors.blue,
+        disabledColor: Colors.grey,
+        backgroundColor: Colors.white,
+        borderRadius: 6,
+        minHeight: 1,
+        child: Text('selected'),
+      );
+
+      await tester.pumpWidget(
+        wrap(
+          TSelectionCardGroupLayout(
+            direction: Axis.vertical,
+            columns: 1,
+            itemHasSubtitles: const [true],
+            children: [selectedCard()],
+          ),
+          token: token,
+        ),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget is SizedBox && widget.height == 90,
+        ),
+        findsOneWidget,
+      );
+      expect(tester.widget<Icon>(find.byIcon(TIcons.check)).size, 16);
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is CustomPaint && widget.size == const Size.square(32),
+        ),
+        findsOneWidget,
+      );
+      final cardContainer = tester
+          .widgetList<Container>(find.byType(Container))
+          .firstWhere(
+            (container) =>
+                container.decoration is BoxDecoration &&
+                (container.decoration! as BoxDecoration).border != null,
+          );
+      final border = (cardContainer.decoration! as BoxDecoration).border!;
+      final markPainter =
+          tester
+                  .widgetList<CustomPaint>(find.byType(CustomPaint))
+                  .map((paint) => paint.painter)
+                  .firstWhere(
+                    (painter) =>
+                        painter.runtimeType.toString() ==
+                        '_SelectionCardMarkPainter',
+                  )
+              as dynamic;
+      expect((border as Border).top.width, 1.875);
+      expect(markPainter.cornerRadius, 5);
+
+      await tester.pumpWidget(
+        wrap(
+          SizedBox(
+            width: 240,
+            child: TSelectionCardGroupLayout(
+              direction: Axis.horizontal,
+              columns: 1,
+              itemHasSubtitles: const [false],
+              children: [selectedCard()],
+            ),
+          ),
+          token: token,
+        ),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget is SizedBox && widget.height == 62,
+        ),
+        findsOneWidget,
+      );
+      expect(tester.widget<Icon>(find.byIcon(TIcons.check)).size, 13.5);
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is CustomPaint && widget.size == const Size.square(27),
         ),
         findsOneWidget,
       );

--- a/tdesign-component/test/components/checkbox/t_checkbox_test.dart
+++ b/tdesign-component/test/components/checkbox/t_checkbox_test.dart
@@ -347,6 +347,64 @@ void main() {
       }
     });
 
+    testWidgets('块高、指示器和卡片高度均读取 TDesign token', (tester) async {
+      final token = TThemeData.defaultData().copyWithTThemeData(
+        'checkbox-size-token-test',
+        fontMap: {
+          'fontBodyLarge': Font(size: 17, lineHeight: 26),
+          'fontBodyMedium': Font(size: 15, lineHeight: 23),
+        },
+        marginMap: const {
+          'spacer4': 5,
+          'spacer8': 9,
+          'spacer16': 18,
+          'spacer24': 27,
+          'spacer48': 51,
+        },
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: TThemeBuilder.light(token),
+          home: Scaffold(
+            body: Column(
+              children: [
+                TCheckbox(
+                  key: const ValueKey('token-block'),
+                  value: true,
+                  title: '块级',
+                  showDivider: false,
+                  onChanged: (_) {},
+                ),
+                TCheckbox(
+                  key: const ValueKey('token-card'),
+                  value: true,
+                  title: '卡片',
+                  subTitle: '说明',
+                  cardMode: true,
+                  onChanged: (_) {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      Finder gesture(String key) => find.descendant(
+        of: find.byKey(ValueKey(key)),
+        matching: find.byType(GestureDetector),
+      );
+      final selectedIcon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byKey(const ValueKey('token-block')),
+          matching: find.byIcon(TIcons.check_circle_filled),
+        ),
+      );
+
+      expect(tester.getSize(gesture('token-block')).height, 60);
+      expect(tester.getSize(gesture('token-card')).height, 90);
+      expect(selectedIcon.size, 27);
+    });
+
     testWidgets('customIconBuilder 接收 value/disabled 状态', (tester) async {
       await tester.pumpWidget(
         wrap(


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？
> 勾选规则:
> 1.只要有新增参数，就勾选”新特性提交“
> 2.只修改内部bug，未新增参数，才勾选”日常 bug 修复“
> 3.其他选项视具体改动判断

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

无关联 Issue。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

Checkbox 的块高、指示器、卡片高度、边框及角标仍包含直接样式数值，导致自定义 TDesign spacer、字体和行高 token 后，组件尺寸不会同步变化。

本次使用现有 TDesign token 组合原有默认尺寸，并保留角标内部的无量纲几何比例；未新增或修改公开 API。默认主题下现有尺寸和视觉保持不变，自定义 token 后 Checkbox 与共享选择卡片会按主题重新计算尺寸。

Spec：[`specs/016-checkbox-theme-token-sizes/`](specs/016-checkbox-theme-token-sizes/)

验证结果：

- Flutter 3.32.0 与 3.47.0：Checkbox/Group/SelectionCard 42 项测试通过，`flutter analyze --fatal-infos` 0 issues。
- Flutter 3.32.0 Linux：Checkbox Demo structure、light/dark Golden 共 3 项，无更新模式通过，基线无需修改。
- 改动生产文件覆盖率 249/261，95.40%。

### 📝 更新日志

<!--
更新日志面向实际使用方用户，请从用户角度描述用户在使用组件或库时能够感知到的具体变化，以及可能的 breaking change 和其他风险。
仅记录用户可感知的变更，不要填写用户无法感知的内部实现、CI/CD 或文档结构调整；如果本次改动用户无法感知，请勾选“本条 PR 不需要纳入 Changelog”。

格式要求：
- 一个 PR 含多个功能 / 修复时，按条目分开列写，不合并。
- 每条遵循 Conventional Commits 的 commit type，与最终分组对应：
  - `breaking` → Breaking Changes
  - `feat` → Features
  - `fix` → Bug Fixes
  - `perf` / `refactor` → Performance
- 示例：`fix(TInput): 修复密文模式下无法粘贴的问题`
-->

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 标题遵循 Conventional Commits 格式：`type(<scope>?): 修改描述`。
      示例：`fix(TBottomTabBar): 修复 iconText 模式底部溢出`
- [x] “相关 Issue”处带上修复的 Issue 链接或无关联 Issue
- [x] 已添加对应的 Spec 链接，或已由 Review 确认本次改动无需 Spec
- [x] 相关文档已补充或无须补充
